### PR TITLE
use d.getUTCDate not d.getUTCDay

### DIFF
--- a/apps/nowcasting-app/components/utils.ts
+++ b/apps/nowcasting-app/components/utils.ts
@@ -31,7 +31,7 @@ export const formatISODateString = (date: string) => {
 
 export const formatISODateStringHuman = (date: string) => {
   const d = new Date(date);
-  const day = d.getUTCDay();
+  const day = d.getUTCDate();
   const month = d.getUTCMonth() + 1;
   const year = d.getFullYear();
   const hours = d.getUTCHours();


### PR DESCRIPTION
# Pull Request

## Description

Fix for datestamps on 
target time and forecast creation time



Fixes #24 

## How Has This Been Tested?

Tested it out with
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCDay

- [x] Yes


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
