### PR TITLE
make all times Europe London

### DIFF
--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -65,7 +65,7 @@ const RemixLine: React.FC<RemixLineProps> = ({ timeOfInterest, data, setTimeOfIn
     return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
   }
   function prettyPrintXdate(x: string) {
-    return convertISODateStringToLondonTime(x + ':00+00:00');
+    return convertISODateStringToLondonTime(x + ":00+00:00");
   }
 
   return (

--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -65,7 +65,7 @@ const RemixLine: React.FC<RemixLineProps> = ({ timeOfInterest, data, setTimeOfIn
     return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
   }
   function prettyPrintXdate(x: string) {
-    return convertISODateStringToLondonTime(x);
+    return convertISODateStringToLondonTime(x + ':00+00:00');
   }
 
   return (

--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -9,7 +9,7 @@ import {
   ResponsiveContainer,
   Tooltip,
 } from "recharts";
-import { formatISODateStringHuman } from "../utils";
+import { convertISODateStringToLondonTime, formatISODateStringHuman } from "../utils";
 
 export type ChartData = {
   GENERATION_UPDATED?: number;
@@ -65,7 +65,7 @@ const RemixLine: React.FC<RemixLineProps> = ({ timeOfInterest, data, setTimeOfIn
     return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
   }
   function prettyPrintXdate(x: string) {
-    return x.slice(11, 16);
+    return convertISODateStringToLondonTime(x);
   }
 
   return (

--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -144,7 +144,7 @@ const RemixLine: React.FC<RemixLineProps> = ({ timeOfInterest, data, setTimeOfIn
             return (
               <div className="p-2 bg-white shadow">
                 <p className="mb-2 text-black">
-                  {formatISODateStringHuman(data?.formatedDate + ":00+00:00")}
+                  {formatISODateStringHuman(data?.formatedDate + ":00+01:00")}
                 </p>
                 <ul className="">
                   {Object.entries(data)

--- a/apps/nowcasting-app/components/utils.ts
+++ b/apps/nowcasting-app/components/utils.ts
@@ -22,7 +22,6 @@ export const classNames = (...classes: string[]) => {
  * @returns HH:MM representation of the date, as string
  */
 export const getTimeFromDate = (date: Date) => {
-    const date_london_time = d.toLocaleTimeString("en-GB", {timeZone: 'Europe/London'}).slice(0,5)
   return date.toTimeString().split(" ")[0].slice(0, -3);
 };
 export const formatISODateString = (date: string) => {

--- a/apps/nowcasting-app/components/utils.ts
+++ b/apps/nowcasting-app/components/utils.ts
@@ -25,33 +25,34 @@ export const getTimeFromDate = (date: Date) => {
   return date.toTimeString().split(" ")[0].slice(0, -3);
 };
 export const formatISODateString = (date: string) => {
-   // Changes the ISO date string to Europe London time, and remove timezone and seconds
+  // Changes the ISO date string to Europe London time, and remove timezone and seconds
 
   const dateid = date?.slice(0, 16);
 
   const d = new Date(date);
-  const date_london_date_str = d.toLocaleDateString("en-GB", {timeZone: 'Europe/London'})
+  const date_london_date_str = d.toLocaleDateString("en-GB", { timeZone: "Europe/London" });
   // make string in DD/MM/YYYY format
-  const date_london_time_str = d.toLocaleTimeString("en-GB", {timeZone: 'Europe/London'}).slice(0,5)
+  const date_london_time_str = d
+    .toLocaleTimeString("en-GB", { timeZone: "Europe/London" })
+    .slice(0, 5);
   // make string in HH:MM format
-  const year = date_london_date_str.slice(6,10)
-  const month = date_london_date_str.slice(3,5)
-  const day = date_london_date_str.slice(0,2)
+  const year = date_london_date_str.slice(6, 10);
+  const month = date_london_date_str.slice(3, 5);
+  const day = date_london_date_str.slice(0, 2);
 
-  const london_datetime = `${year}-${month}-${day}T${date_london_time_str}`
+  const london_datetime = `${year}-${month}-${day}T${date_london_time_str}`;
 
-  return london_datetime
+  return london_datetime;
 };
 
 export const formatISODateStringHuman = (date: string) => {
-    // Change date to nice human readable format.
-    // Note that this converts the string to Europe London Time
-    // timezone and seconds are removed
-    const d = new Date(date);
-    const date_london = d.toLocaleDateString("en-GB", {timeZone: 'Europe/London'});
-    const date_london_time = d.toLocaleTimeString("en-GB", {timeZone: 'Europe/London'}).slice(0,5);
+  // Change date to nice human readable format.
+  // Note that this converts the string to Europe London Time
+  // timezone and seconds are removed
+  const d = new Date(date);
+  const date_london = d.toLocaleDateString("en-GB", { timeZone: "Europe/London" });
+  const date_london_time = d.toLocaleTimeString("en-GB", { timeZone: "Europe/London" }).slice(0, 5);
 
-    // further formatting could be done to make it yyyy/mm/dd HH:MM
-    return `${date_london} ${date_london_time}`
+  // further formatting could be done to make it yyyy/mm/dd HH:MM
+  return `${date_london} ${date_london_time}`;
 };
-

--- a/apps/nowcasting-app/components/utils.ts
+++ b/apps/nowcasting-app/components/utils.ts
@@ -25,7 +25,7 @@ export const getTimeFromDate = (date: Date) => {
   return date.toTimeString().split(" ")[0].slice(0, -3);
 };
 export const formatISODateString = (date: string) => {
-   // Changes the ISO date string to Europe London time
+   // Changes the ISO date string to Europe London time, and remove timezone and seconds
 
   const dateid = date?.slice(0, 16);
 
@@ -46,11 +46,12 @@ export const formatISODateString = (date: string) => {
 export const formatISODateStringHuman = (date: string) => {
     // Change date to nice human readable format.
     // Note that this converts the string to Europe London Time
+    // timezone and seconds are removed
     const d = new Date(date);
     const date_london = d.toLocaleDateString("en-GB", {timeZone: 'Europe/London'});
     const date_london_time = d.toLocaleTimeString("en-GB", {timeZone: 'Europe/London'}).slice(0,5);
 
-    // further formatting could be done to make it yyyy/mm/dd HH:DD
+    // further formatting could be done to make it yyyy/mm/dd HH:MM
     return `${date_london} ${date_london_time}`
 };
 

--- a/apps/nowcasting-app/components/utils.ts
+++ b/apps/nowcasting-app/components/utils.ts
@@ -22,21 +22,36 @@ export const classNames = (...classes: string[]) => {
  * @returns HH:MM representation of the date, as string
  */
 export const getTimeFromDate = (date: Date) => {
+    const date_london_time = d.toLocaleTimeString("en-GB", {timeZone: 'Europe/London'}).slice(0,5)
   return date.toTimeString().split(" ")[0].slice(0, -3);
 };
 export const formatISODateString = (date: string) => {
+   // Changes the ISO date string to Europe London time
+
   const dateid = date?.slice(0, 16);
-  return dateid;
+
+  const d = new Date(date);
+  const date_london_date_str = d.toLocaleDateString("en-GB", {timeZone: 'Europe/London'})
+  // make string in DD/MM/YYYY format
+  const date_london_time_str = d.toLocaleTimeString("en-GB", {timeZone: 'Europe/London'}).slice(0,5)
+  // make string in HH:MM format
+  const year = date_london_date_str.slice(6,10)
+  const month = date_london_date_str.slice(3,5)
+  const day = date_london_date_str.slice(0,2)
+
+  const london_datetime = `${year}-${month}-${day}T${date_london_time_str}`
+
+  return london_datetime
 };
 
 export const formatISODateStringHuman = (date: string) => {
-  const d = new Date(date);
-  const day = d.getUTCDay();
-  const month = d.getUTCMonth() + 1;
-  const year = d.getFullYear();
-  const hours = d.getUTCHours();
-  const minutes = d.getUTCMinutes();
-  const hourss = hours < 10 ? `0${hours}` : hours;
-  const minutess = minutes < 10 ? `0${minutes}` : minutes;
-  return `${day}/${month}/${year} ${hourss}:${minutess}`;
+    // Change date to nice human readable format.
+    // Note that this converts the string to Europe London Time
+    const d = new Date(date);
+    const date_london = d.toLocaleDateString("en-GB", {timeZone: 'Europe/London'});
+    const date_london_time = d.toLocaleTimeString("en-GB", {timeZone: 'Europe/London'}).slice(0,5);
+
+    // further formatting could be done to make it yyyy/mm/dd HH:DD
+    return `${date_london} ${date_london_time}`
 };
+

--- a/apps/nowcasting-app/components/utils.ts
+++ b/apps/nowcasting-app/components/utils.ts
@@ -25,24 +25,19 @@ export const getTimeFromDate = (date: Date) => {
   return date.toTimeString().split(" ")[0].slice(0, -3);
 };
 export const formatISODateString = (date: string) => {
-  // Changes the ISO date string to Europe London time, and remove timezone and seconds
+  // remove timezone and seconds
 
   const dateid = date?.slice(0, 16);
-
+  return dateid;
+};
+export const convertISODateStringToLondonTime = (date: string) => {
+  // Changes the ISO date string to Europe London time, and return time only
   const d = new Date(date);
-  const date_london_date_str = d.toLocaleDateString("en-GB", { timeZone: "Europe/London" });
-  // make string in DD/MM/YYYY format
   const date_london_time_str = d
     .toLocaleTimeString("en-GB", { timeZone: "Europe/London" })
     .slice(0, 5);
-  // make string in HH:MM format
-  const year = date_london_date_str.slice(6, 10);
-  const month = date_london_date_str.slice(3, 5);
-  const day = date_london_date_str.slice(0, 2);
 
-  const london_datetime = `${year}-${month}-${day}T${date_london_time_str}`;
-
-  return london_datetime;
+  return date_london_time_str;
 };
 
 export const formatISODateStringHuman = (date: string) => {


### PR DESCRIPTION
# Pull Request

## Description

Change all times to 'Europe/London'

- HH:MM are correct in graph
- forecast creation time is in 'Europe/London'
- target datetime is in 'Europe/London'

This was take around 09:14 Europe London time
<img width="1392" alt="Screenshot 2022-06-15 at 09 14 17" src="https://user-images.githubusercontent.com/34686298/173777933-81cdb8a3-6628-41e2-b7eb-b89c30a637a5.png">

Fixes #55 

## How Has This Been Tested?

ran it locally, checked
- forecast creation time
- targte time on graph
- x lables
- label in hover on national gsp
- GSP plot looks correct too

Also CI check it builds

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
