### PR TITLE
move forecast creationg time up a bit

### DIFF
--- a/apps/nowcasting-app/components/charts/pv-remix-chart.tsx
+++ b/apps/nowcasting-app/components/charts/pv-remix-chart.tsx
@@ -68,7 +68,7 @@ const PvRemixChart: FC<{ date?: string }> = (props) => {
     setSelectedISOTime(time + ":00.000Z");
   };
   return (
-    <div className="flex flex-col" style={{ minHeight: `calc(100vh - 70px)` }}>
+    <div className="flex flex-col" style={{ minHeight: `calc(100vh - 110px)` }}>
       <div className="flex-grow">
         <ForecastHeader pv={latestPvGenerationInGW}>
           <PlatButton


### PR DESCRIPTION
# Pull Request

## Description

Move forecast creation time up a tiny bit, so that it doesnt over lap the footer

Fixes #

## How Has This Been Tested?

ran locally

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
