### PR TITLE
Issue/83 label twice

### DIFF
--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -133,7 +133,7 @@ const RemixLine: React.FC<RemixLineProps> = ({ timeOfInterest, data, setTimeOfIn
           type="monotone"
           dataKey="FORECAST"
           dot={false}
-          strokeDasharray="7 7"
+          strokeDasharray="10 10"
           stroke="#FFC425" //yellow
           strokeWidth={3}
         />

--- a/apps/nowcasting-app/components/charts/use-format-chart-data.tsx
+++ b/apps/nowcasting-app/components/charts/use-format-chart-data.tsx
@@ -19,7 +19,6 @@ const getForecastChartData = (
   else if (new Date(fr.targetTime).getTime() === new Date(selectedTime + ":00.000Z").getTime())
     return {
       FORECAST: Math.round(fr.expectedPowerGenerationMegawatts),
-      PAST_FORECAST: Math.round(fr.expectedPowerGenerationMegawatts),
     };
   else
     return {


### PR DESCRIPTION
# Pull Request

## Description

Only have one data point at 'now'

<img width="573" alt="Screenshot 2022-06-15 at 18 51 50" src="https://user-images.githubusercontent.com/34686298/173892835-5cc2106a-93af-460b-b045-bf5dee37b890.png">

WARNING might need a merge after 

Fixes #83 

## How Has This Been Tested?

ran locally

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
