### PR TITLE
add set creation time when getting forecast data (#101)

### DIFF
--- a/apps/nowcasting-app/components/map/pvLatest.tsx
+++ b/apps/nowcasting-app/components/map/pvLatest.tsx
@@ -35,6 +35,9 @@ const useGetForecastsData = (isNormalized: boolean) => {
   const allForecastData = useSWR<FcAllResData>(() => getAllForecastUrl(true, true), fetcher, {
     refreshInterval: 1000 * 60 * 5, // 5min
     isPaused: () => forecastLoading,
+    onSuccess: (data) => {
+        setForecastCreationTime(data.forecasts[0].forecastCreationTime);
+    }
   });
   useEffect(() => {
     if (!forecastLoading) {

--- a/apps/nowcasting-app/components/map/pvLatest.tsx
+++ b/apps/nowcasting-app/components/map/pvLatest.tsx
@@ -36,8 +36,8 @@ const useGetForecastsData = (isNormalized: boolean) => {
     refreshInterval: 1000 * 60 * 5, // 5min
     isPaused: () => forecastLoading,
     onSuccess: (data) => {
-        setForecastCreationTime(data.forecasts[0].forecastCreationTime);
-    }
+      setForecastCreationTime(data.forecasts[0].forecastCreationTime);
+    },
   });
   useEffect(() => {
     if (!forecastLoading) {


### PR DESCRIPTION
# Pull Request

## Description

Update forecast creation time

Fixes #101 

## How Has This Been Tested?

Ran locally
waited 10 mins, and time did update

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
