### PR TITLE
Issue/ymax gsp graph (#133)

### DIFF
--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
@@ -67,7 +67,7 @@ const GspPvRemixChart: FC<{
           setTimeOfInterest={setTimeOfInterest}
           timeOfInterest={selectedTime}
           data={chartData}
-          yMax={yMax}
+          yMax={yMax!}
         />
       </div>
     </>

--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
@@ -40,7 +40,7 @@ const GspPvRemixChart: FC<{
   const pvPercentage = (forcastAtSelectedTime.expectedPowerGenerationNormalized || 0) * 100;
 
   // set ymax to the installed capacity of the graph
-  var yMax = gspInfo?.installedCapacityMw || 100;
+  let yMax = gspInfo?.installedCapacityMw || 100;
 
   // lets round it up to the 'yMax_levels' so that the y major ticks look right.
   for (var i = 0; i < yMax_levels.length; i++) {

--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
@@ -43,7 +43,7 @@ const GspPvRemixChart: FC<{
   var yMax = gspInfo?.installedCapacityMw;
 
   // lets round it up to the 'yMax_levels' so that the y major ticks look right.
-  if (typeof myVar !== undefined) {
+  if (typeof yMax !== undefined) {
     for (var i = 0; i < yMax_levels.length; i++) {
       var level = yMax_levels[i];
       yMax = yMax < level ? level : yMax;

--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
@@ -43,11 +43,13 @@ const GspPvRemixChart: FC<{
   var yMax = gspInfo?.installedCapacityMw;
 
   // lets round it up to the 'yMax_levels' so that the y major ticks look right.
-  for (var i = 0; i < yMax_levels.length; i++) {
-    var level = yMax_levels[i];
-    yMax = yMax < level ? level : yMax;
-    if (yMax === level) {
-      break;
+  if (typeof myVar !== undefined) {
+    for (var i = 0; i < yMax_levels.length; i++) {
+      var level = yMax_levels[i];
+      yMax = yMax < level ? level : yMax;
+      if (yMax === level) {
+        break;
+      }
     }
   }
 

--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
@@ -40,12 +40,12 @@ const GspPvRemixChart: FC<{
   const pvPercentage = (forcastAtSelectedTime.expectedPowerGenerationNormalized || 0) * 100;
 
   // set ymax to the installed capacity of the graph
-  var yMax = gspInfo?.installedCapacityMw;
+  var yMax = gspInfo?.installedCapacityMw || 100;
 
   // lets round it up to the 'yMax_levels' so that the y major ticks look right.
   for (var i = 0; i < yMax_levels.length; i++) {
     var level = yMax_levels[i];
-    yMax = yMax! < level ? level : yMax;
+    yMax = yMax < level ? level : yMax;
     if (yMax === level) {
       break;
     }

--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
@@ -6,6 +6,11 @@ import ForecastHeaderGSP from "./forecast-header-gsp";
 import useGetGspData from "./use-get-gsp-data";
 import Spinner from "../../spinner";
 
+// We want to have the ymax of the graph to be related to the capacity of the GspPvRemixChart
+// If we use the raw values, the graph looks funny, i.e y major ticks are 0 100 232
+// So, we round these up to the following numbers
+const yMax_levels = [3, 9, 20, 45, 60, 100, 200, 300, 450, 600];
+
 const GspPvRemixChart: FC<{
   gspId: number;
   selectedTime: string;
@@ -33,6 +38,19 @@ const GspPvRemixChart: FC<{
     gspForecastData?.find((fc) => formatISODateString(fc?.targetTime) === selectedTime) ||
     ({} as any);
   const pvPercentage = (forcastAtSelectedTime.expectedPowerGenerationNormalized || 0) * 100;
+
+  // set ymax to the installed capacity of the graph
+  var yMax = gspInfo.installedCapacityMw;
+
+  // lets round it up to the 'yMax_levels' so that the y major ticks look right.
+  for (var i = 0; i < yMax_levels.length; i++) {
+    var level = yMax_levels[i];
+    yMax = yMax < level ? level : yMax;
+    if (yMax === level) {
+      break;
+    }
+  }
+
   return (
     <>
       <div className="bg-black">
@@ -49,7 +67,7 @@ const GspPvRemixChart: FC<{
           setTimeOfInterest={setTimeOfInterest}
           timeOfInterest={selectedTime}
           data={chartData}
-          yMax="auto"
+          yMax={yMax}
         />
       </div>
     </>

--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
@@ -43,13 +43,11 @@ const GspPvRemixChart: FC<{
   var yMax = gspInfo?.installedCapacityMw;
 
   // lets round it up to the 'yMax_levels' so that the y major ticks look right.
-  if (typeof yMax !== undefined) {
-    for (var i = 0; i < yMax_levels.length; i++) {
-      var level = yMax_levels[i];
-      yMax = yMax < level ? level : yMax;
-      if (yMax === level) {
-        break;
-      }
+  for (var i = 0; i < yMax_levels.length; i++) {
+    var level = yMax_levels[i];
+    yMax = yMax! < level ? level : yMax;
+    if (yMax === level) {
+      break;
     }
   }
 

--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
@@ -40,7 +40,7 @@ const GspPvRemixChart: FC<{
   const pvPercentage = (forcastAtSelectedTime.expectedPowerGenerationNormalized || 0) * 100;
 
   // set ymax to the installed capacity of the graph
-  var yMax = gspInfo.installedCapacityMw;
+  var yMax = gspInfo?.installedCapacityMw;
 
   // lets round it up to the 'yMax_levels' so that the y major ticks look right.
   for (var i = 0; i < yMax_levels.length; i++) {


### PR DESCRIPTION
# Pull Request

## Description

Fix ymax on GSP plot to be the installed capacity of the GSP

Need to round up the ymax value to th following levels, so that y major ticks looked right
[3, 9, 20, 45, 60, 100, 200, 300, 450, 600];

<img width="418" alt="Screenshot 2022-06-29 at 11 57 18" src="https://user-images.githubusercontent.com/34686298/176420642-79e7b570-c57b-4faa-a6c7-a15312e7128e.png">

<img width="442" alt="Screenshot 2022-06-29 at 11 57 13" src="https://user-images.githubusercontent.com/34686298/176420615-c7a0b4ab-3c27-4005-8ed0-b59bb8868f13.png">

Fixes #133 


## How Has This Been Tested?

ran locally

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
