### PR TITLE
#202: remove round button & set default

### DIFF
--- a/apps/nowcasting-app/components/map/pvLatest.tsx
+++ b/apps/nowcasting-app/components/map/pvLatest.tsx
@@ -16,12 +16,12 @@ import { theme } from "../../tailwind.config";
 import ColorGuideBar from "./color-guide-bar";
 const yellow = theme.extend.colors["ocf-yellow"].DEFAULT;
 
-const getRoundedPv = (pv: number, round: boolean) => {
+const getRoundedPv = (pv: number, round: boolean = true) => {
   if (!round) return Math.round(pv);
   // round To: 0, 100, 200, 300, 400, 500
   return Math.round(pv / 100) * 100;
 };
-const getRoundedPvPercent = (per: number, round: boolean) => {
+const getRoundedPvPercent = (per: number, round: boolean = true) => {
   if (!round) return per;
   // round to : 0, 0.2, 0.4, 0.6 0.8, 1
   let rounded = Math.round(per * 10);
@@ -64,7 +64,6 @@ const useGetForecastsData = (isNormalized: boolean) => {
 
 const PvLatestMap = () => {
   const [activeUnit, setActiveUnit] = useState<ActiveUnit>(ActiveUnit.MW);
-  const [round, setRound] = useState(false);
   const [selectedISOTime] = useGlobalState("selectedISOTime");
 
   const isNormalized = activeUnit === ActiveUnit.percentage;
@@ -113,11 +112,10 @@ const PvLatestMap = () => {
           properties: {
             ...featureObj.properties,
             expectedPowerGenerationMegawatts:
-              selectedFCvalue &&
-              getRoundedPv(selectedFCvalue.expectedPowerGenerationMegawatts, round),
+              selectedFCvalue && getRoundedPv(selectedFCvalue.expectedPowerGenerationMegawatts),
             expectedPowerGenerationNormalized:
               selectedFCvalue &&
-              getRoundedPvPercent(selectedFCvalue?.expectedPowerGenerationNormalized || 0, round),
+              getRoundedPvPercent(selectedFCvalue?.expectedPowerGenerationNormalized || 0),
           },
         };
       }),
@@ -127,7 +125,7 @@ const PvLatestMap = () => {
   };
   const generatedGeoJsonForecastData = useMemo(() => {
     return generateGeoJsonForecastData(initForecastData, selectedISOTime);
-  }, [initForecastData, selectedISOTime, round]);
+  }, [initForecastData, selectedISOTime]);
 
   const updateMapData = (map: mapboxgl.Map) => {
     const source = map.getSource("latestPV") as unknown as mapboxgl.GeoJSONSource | undefined;
@@ -196,16 +194,6 @@ const PvLatestMap = () => {
       controlOverlay={(map: { current?: mapboxgl.Map }) => (
         <>
           <ButtonGroup rightString={formatISODateStringHuman(selectedISOTime || "")} />
-          <div className="inline-block">
-            <button
-              className={`relative inline-flex items-center px-3 py-1 ml-px text-sm font-extrabold  ${
-                round ? "text-black bg-amber-400" : "text-white bg-black"
-              } hover:bg-amber-4`}
-              onClick={() => setRound((r) => !r)}
-            >
-              round
-            </button>
-          </div>
           <MeasuringUnit
             activeUnit={activeUnit}
             setActiveUnit={setActiveUnit}


### PR DESCRIPTION
# Pull Request

## Description

Removed `ROUND` button and set default to true. 

NB have left the boolean parameters in place in the round functions as this seems like functionality that make resurface in a different form/use case when the dash becomes more interactive.

## How Has This Been Tested?
Visual testing, and manually switched on and off boolean in code to compare map with rounded/non-rounded figures.
Screenshot attached.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/41056982/189157825-16b2f357-8eca-4cd1-b970-bb47239913d7.png">
