### PR TITLE
update background color of pv remix chart key 

### DIFF
--- a/apps/nowcasting-app/components/charts/pv-remix-chart.tsx
+++ b/apps/nowcasting-app/components/charts/pv-remix-chart.tsx
@@ -119,7 +119,7 @@ const PvRemixChart: FC<{ date?: string }> = () => {
           ></GspPvRemixChart>
         )}
       </div>
-      <div className="flex-0 px-3 text-[11px] tracking-wider text-ocf-gray-300 py-2 bg-ocf-gray-800">
+      <div className="flex-0 px-3 text-[12px] tracking-wider text-ocf-gray-300 py-2 bg-mapbox-black-500">
         <div className="flex justify-around">
           <LegendItem iconClasses={"text-ocf-black"} dashed label={"PV live initial estimate"} />
           <LegendItem iconClasses={"text-ocf-black"} label={"PV live updated"} />


### PR DESCRIPTION
# Pull Request

## Description

Updates background color or the pv remix chart key to mapbox-black-500. 
Updates font-size to be a little bigger, 12px instead of 11px. It seemed to look better. 

Design suggestion: 

![190191039-753a99bd-5abe-4bce-91f8-a1e832fd3254](https://user-images.githubusercontent.com/86949265/190637538-6f23e1e1-2bb8-4f32-a62b-71d1513f65e2.png)

Current: 

![190190936-d4646898-105f-4bf7-8b6b-49d05e10e258](https://user-images.githubusercontent.com/86949265/190637573-40d1d3a1-74dc-43f9-a762-a8691132c224.png)

New: 

<img width="661" alt="Screenshot 2022-09-16 at 14 10 00" src="https://user-images.githubusercontent.com/86949265/190637639-f22b1997-72b9-4808-b6ba-ad6ebb8e7f65.png">

Fixes #215 

## How Has This Been Tested?

Tested visually by running the code locally. 



## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
