### PR TITLE
Feat/214 update pv remix pop up font and layout

### DIFF
--- a/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
+++ b/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
@@ -45,7 +45,7 @@ const ForecastHeaderUI: React.FC<ForecastHeaderProps> = ({
       <div
         className={` bg-white text-black lg:text-2xl md:text-lg text-sm font-black  p-4 py-2  flex-[2] `}
       >
-        National
+        National Solar PV <span className={`text-base text-ocf-gray-900 ml-5`}>GW</span>
       </div>
       <PVNumber pv={actualPV} subTitle={`${pvTimeOnly} PVLive`} color="black" />
       <PVNumber pv={forcastPV} subTitle={`${selectedTimeOnly} Forecast`} />

--- a/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
+++ b/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
@@ -43,7 +43,7 @@ const ForecastHeaderUI: React.FC<ForecastHeaderProps> = ({
   return (
     <div className={"flex content-between flex-wrap mt-6 h-auto"}>
       <div
-        className={` bg-white text-black lg:text-2xl md:text-lg text-sm font-black  p-4 py-2  flex-[2] `}
+        className={`bg-white text-black lg:text-2xl md:text-lg text-sm font-black p-4 py-2 flex-[2]`}
       >
         National Solar PV <span className={`text-base text-ocf-gray-900 ml-2`}>GW</span>
       </div>

--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -201,25 +201,25 @@ const RemixLine: React.FC<RemixLineProps> = ({
                           if (name === "formatedDate") return null;
                           return (
                             <li
-                              className="font-sans, text-left flex"
+                              className={`font-sans`}
                               key={`item-${name}`}
                               style={{ color: toolTipColors[name] }}
                             >
-                              <div>
-                                {toolTiplabels[name]}:{" "}
-                                <span className="font-serif text-sm ml-7">
+                              <div className={`flex justify-between lg-font-bold`}>
+                                <div>{toolTiplabels[name]}:{" "}</div>
+                                <div className="font-serif text-sm ml-7">
                                   {" "}
                                   {prettyPrintYNumberWithCommas(value as string)}{" "}
-                                </span>
+                                </div>
                               </div>
                             </li>
                           );
                         })}
-                      <li className="pt-2 text-left text-sm text-white font-serif flex-wrap">
+                      <li className={`flex justify-between pt-2 text-sm text-white font-serif`}>
                         <div>
                           {formatISODateStringHuman(data?.formatedDate + ":00+00:00")}{" "}
-                          <span className="text-right font-serif ml-10">MW</span>
-                        </div>
+                          </div>
+                        <div className={`font-serif`}>MW</div>
                       </li>
                     </ul>
                   </div>

--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -205,9 +205,9 @@ const RemixLine: React.FC<RemixLineProps> = ({
                               key={`item-${name}`}
                               style={{ color: toolTipColors[name] }}
                             >
-                              <div className={`flex justify-between lg-font-bold`}>
-                                <div>{toolTiplabels[name]}:{" "}</div>
-                                <div className="font-serif text-sm ml-7">
+                              <div className={`flex justify-between`}>
+                                <div className={`font-extrabold`}>{toolTiplabels[name]}:{" "}</div>
+                                <div className="font-serif font-extrabold text-sm ml-7">
                                   {" "}
                                   {prettyPrintYNumberWithCommas(value as string)}{" "}
                                 </div>
@@ -215,11 +215,11 @@ const RemixLine: React.FC<RemixLineProps> = ({
                             </li>
                           );
                         })}
-                      <li className={`flex justify-between pt-2 text-sm text-white font-serif`}>
+                      <li className={`flex justify-between pt-4 text-sm text-white font-serif`}>
                         <div>
                           {formatISODateStringHuman(data?.formatedDate + ":00+00:00")}{" "}
                           </div>
-                        <div className={`font-serif`}>MW</div>
+                        <div>MW</div>
                       </li>
                     </ul>
                   </div>

--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -22,7 +22,7 @@ export type ChartData = {
 
 const toolTiplabels: Record<string, string> = {
   GENERATION_UPDATED: "PV Live updated",
-  GENERATION: "PV Live initial estimate",
+  GENERATION: "PV Live estimate",
   FORECAST: "OCF Forecast",
   PAST_FORECAST: "OCF Forecast",
 };
@@ -194,9 +194,6 @@ const RemixLine: React.FC<RemixLineProps> = ({
                 if (!data) return <div></div>;
                 return (
                   <div className="p-2 bg-mapbox-black bg-opacity-70 shadow">
-                    <p className="mb-2 text-white">
-                      {formatISODateStringHuman(data?.formatedDate + ":00+00:00")}
-                    </p>
                     <ul className="">
                       {Object.entries(data)
                         .reverse()
@@ -204,15 +201,26 @@ const RemixLine: React.FC<RemixLineProps> = ({
                           if (name === "formatedDate") return null;
                           return (
                             <li
-                              className="font-bold"
+                              className="font-sans, text-left flex"
                               key={`item-${name}`}
                               style={{ color: toolTipColors[name] }}
                             >
-                              {toolTiplabels[name]}: {prettyPrintYNumberWithCommas(value as string)}{" "}
-                              MW
+                              <div>
+                                {toolTiplabels[name]}:{" "}
+                                <span className="font-serif text-sm ml-7">
+                                  {" "}
+                                  {prettyPrintYNumberWithCommas(value as string)}{" "}
+                                </span>
+                              </div>
                             </li>
                           );
                         })}
+                      <li className="pt-2 text-left text-sm text-white font-serif flex-wrap">
+                        <div>
+                          {formatISODateStringHuman(data?.formatedDate + ":00+00:00")}{" "}
+                          <span className="text-right font-serif ml-10">MW</span>
+                        </div>
+                      </li>
                     </ul>
                   </div>
                 );

--- a/apps/nowcasting-app/package.json
+++ b/apps/nowcasting-app/package.json
@@ -30,7 +30,8 @@
     "turbo": "^1.0.26"
   },
   "devDependencies": {
-    "@babel/core": "^7.17.0",
+    "@babel/core": "^7.19.1",
+    "@babel/eslint-parser": "^7.19.1",
     "@openclimatefix/nowcasting-tsconfig": "*",
     "@storybook/addon-actions": "^6.4.22",
     "@storybook/addon-essentials": "^6.4.22",
@@ -47,6 +48,7 @@
     "autoprefixer": "^10.4.7",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.5",
+    "eslint": "^8.23.1",
     "eslint-config-next": "^12.3.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/apps/nowcasting-app/tailwind.config.js
+++ b/apps/nowcasting-app/tailwind.config.js
@@ -17,7 +17,7 @@ module.exports = {
       fontFamily: {
         sans: ["Inter", ...defaultTheme.fontFamily.sans],
         mono: ["ui-monospace", ...defaultTheme.fontFamily.mono],
-        serif: ["Fira Code", ...defaultTheme.fontFamily.serif],
+        serif: ["Source Code Pro", ...defaultTheme.fontFamily.serif],
       },
       colors: {
         amber: {

--- a/apps/nowcasting-app/tailwind.config.js
+++ b/apps/nowcasting-app/tailwind.config.js
@@ -1,4 +1,4 @@
-const defaultTheme = require("tailwindcss/defaultTheme");
+const defaultTheme = require("tailwindcss/defaultTheme")
 
 module.exports = {
   content: ["./pages/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
@@ -16,6 +16,8 @@ module.exports = {
     extend: {
       fontFamily: {
         sans: ["Inter", ...defaultTheme.fontFamily.sans],
+        mono: ["ui-monospace", ...defaultTheme.fontFamily.mono],
+        serif: ["Fira Code", ...defaultTheme.fontFamily.serif],
       },
       colors: {
         amber: {
@@ -133,4 +135,4 @@ module.exports = {
     },
   },
   plugins: [require("@tailwindcss/forms"), require("@tailwindcss/typography")],
-};
+}


### PR DESCRIPTION
# Pull Request

## Description

Updates the layout of the tooltip pop-up box on the `pv-remix-chart`. 
I also changed the chart titles (National and GSP labels) to bold while on this branch.   

Previous:
![](https://user-images.githubusercontent.com/86949265/190188104-d019dc8b-0af6-440a-9f7c-7da7ea1a7383.png)


Design suggestion: 

![](https://user-images.githubusercontent.com/86949265/190187623-97b98d53-5466-4286-8f4d-46f1f05e97d1.png)

Updated with `Source Code Pro` as the code-ish font. This was the font mentioned in the design meeting this week: 

<img width="269" alt="Screenshot 2022-09-22 at 12 33 32" src="https://user-images.githubusercontent.com/86949265/191727056-f6f6c8b4-5709-4dbb-99a2-d8ed77f14095.png">
 
It was particularly challenging to try to put the `OCF Forecast + numbers` alone in bold and not bold the PV Live numbers since they are all part of the same array of data being mapped and styled together. So would welcome any suggestions. 

Fixes #214 

## How Has This Been Tested?

This was visually tested by running the app locally. 

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
