### PR TITLE
Feat/219 move buttons and feat/220 move and update date 

### DIFF
--- a/apps/nowcasting-app/components/button-group.tsx
+++ b/apps/nowcasting-app/components/button-group.tsx
@@ -25,7 +25,7 @@ const ButtonGroup = ({ rightString }: IButtonGroup) => {
       >
         DELTA
       </button>
-      <div className="absolute right-5 top-0 items-center px-3 py-1 ml-px text-md font-medium text-white bg-ocf-black ">
+       <div className="absolute left-0 top-0 items-center px-3 py-1 ml-px text-md font-bold text-black bg-white">
         {rightString}
       </div>
     </span>

--- a/apps/nowcasting-app/components/button-group.tsx
+++ b/apps/nowcasting-app/components/button-group.tsx
@@ -4,28 +4,28 @@ interface IButtonGroup {
 
 const ButtonGroup = ({ rightString }: IButtonGroup) => {
   return (
-    <span className="relative z-0 w-full inline-flex shadow-sm">
+    <span className="relative z-0 w-full flex justify-end shadow-sm mx-0">
       <button
         type="button"
-        className="relative inline-flex items-center px-3 py-1 text-sm font-extrabold text-black bg-ocf-yellow disabled:cursor-not-allowed hover:bg-ocf-yellow focus:z-10 focus:bg-ocf-yellow focus:text-black"
+        className="relative w-32 items-center px-3 py-2 text-sm mx-2 font-extrabold text-black bg-ocf-yellow disabled:cursor-not-allowed hover:bg-ocf-yellow focus:z-10 focus:bg-ocf-yellow focus:text-black"
       >
         PV FORECAST
       </button>
       <button
         type="button"
         disabled
-        className="relative inline-flex items-center px-3 py-1 ml-px text-sm font-extrabold text-white bg-black disabled:cursor-not-allowed focus:z-10 focus:bg-ocf-yellow focus:text-black"
+        className="relative w-32 items-center px-3 py-2 mx-2 ml-px text-sm font-extrabold text-white bg-black disabled:cursor-not-allowed focus:z-10 focus:bg-ocf-yellow focus:text-black"
       >
         SOLAR SITES
       </button>
       <button
         type="button"
         disabled
-        className="relative inline-flex items-center px-3 py-1 ml-px text-sm font-extrabold text-white bg-black disabled:cursor-not-allowed focus:z-10 focus:bg-ocf-yellow focus:text-black"
+        className="relative w-32 items-center px-3 py-2 ml-px text-sm font-extrabold text-white bg-black disabled:cursor-not-allowed focus:z-10 focus:bg-ocf-yellow focus:text-black"
       >
         DELTA
       </button>
-       <div className="absolute left-0 top-0 items-center px-3 py-1 ml-px text-md font-bold text-black bg-white">
+       <div className="absolute left-0 top-0 items-center px-3 py-2 mx-1  ml-px text-lg font-extrabold text-black bg-white">
         {rightString}
       </div>
     </span>

--- a/apps/nowcasting-app/components/map/measuringUnit.tsx
+++ b/apps/nowcasting-app/components/map/measuringUnit.tsx
@@ -18,13 +18,13 @@ const MeasuringUnit = ({
   };
 
   return (
-    <div className="mt-1 flex justify-items-end">
+    <div className="mt-2 flex justify-end mr-0">
       <div className="inline-block">
         <button
           onClick={(event) => onToggle(event, ActiveUnit.MW)}
           disabled={isLoading}
           type="button"
-          className={`relative inline-flex items-center px-3 py-1 ml-px text-sm font-extrabold  ${
+          className={`relative w-12inline-flex items-center px-3 py-2 mx-1 ml-px text-sm font-extrabold  ${
             activeUnit === "MW" ? "text-black bg-ocf-yellow" : "text-white bg-black"
           } ${isLoading ? "cursor-wait" : ""} hover:bg-ocf-yellow`}
         >
@@ -34,7 +34,7 @@ const MeasuringUnit = ({
           onClick={(event) => onToggle(event, ActiveUnit.percentage)}
           disabled={isLoading}
           type="button"
-          className={`relative inline-flex items-center px-3 py-1 text-sm font-extrabold ${
+          className={`relative inline-flex items-center px-4 py-2 ml-1 mr-px text-sm font-extrabold ${
             activeUnit === "%" ? "text-black bg-ocf-yellow" : "text-white bg-black"
           }  ${isLoading ? "cursor-wait" : ""} hover:bg-ocf-yellow`}
         >

--- a/apps/nowcasting-app/components/map/measuringUnit.tsx
+++ b/apps/nowcasting-app/components/map/measuringUnit.tsx
@@ -18,7 +18,7 @@ const MeasuringUnit = ({
   };
 
   return (
-    <div className="mt-1">
+    <div className="mt-1 flex justify-items-end">
       <div className="inline-block">
         <button
           onClick={(event) => onToggle(event, ActiveUnit.MW)}

--- a/apps/nowcasting-app/components/utils.ts
+++ b/apps/nowcasting-app/components/utils.ts
@@ -42,16 +42,28 @@ export const convertISODateStringToLondonTime = (date: string) => {
   return date_london_time_str;
 };
 
+
 export const formatISODateStringHuman = (date: string) => {
   // Change date to nice human readable format.
   // Note that this converts the string to Europe London Time
   // timezone and seconds are removed
+
   const d = new Date(date);
-  const date_london = d.toLocaleDateString("en-GB", { timeZone: "Europe/London" });
-  const date_london_time = d.toLocaleTimeString("en-GB", { timeZone: "Europe/London" }).slice(0, 5);
+  
+  const options = {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'Europe/London'
+  };
+  
+  const date_london = d.toLocaleString("en-GB", options);
+  // const date_london_time = d.toLocaleTimeString("en-GB", { timeZone: "Europe/London" }).slice(0, 5);
 
   // further formatting could be done to make it yyyy/mm/dd HH:MM
-  return `${date_london} ${date_london_time}`;
+  // return `${date_london} ${date_london_time}`;
+  return `${date_london}`;
 };
 
 export const MWtoGW = (MW: number) => {

--- a/apps/nowcasting-app/components/utils.ts
+++ b/apps/nowcasting-app/components/utils.ts
@@ -50,15 +50,13 @@ export const formatISODateStringHuman = (date: string) => {
 
   const d = new Date(date);
   
-  const options = {
+  const date_london = d.toLocaleString("en-GB", {
     weekday: 'long',
     day: 'numeric',
     month: 'long',
     year: 'numeric',
     timeZone: 'Europe/London'
-  };
-  
-  const date_london = d.toLocaleString("en-GB", options);
+  });
   // const date_london_time = d.toLocaleTimeString("en-GB", { timeZone: "Europe/London" }).slice(0, 5);
 
   // further formatting could be done to make it yyyy/mm/dd HH:MM

--- a/apps/nowcasting-app/components/utils.ts
+++ b/apps/nowcasting-app/components/utils.ts
@@ -57,10 +57,6 @@ export const formatISODateStringHuman = (date: string) => {
     year: 'numeric',
     timeZone: 'Europe/London'
   });
-  // const date_london_time = d.toLocaleTimeString("en-GB", { timeZone: "Europe/London" }).slice(0, 5);
-
-  // further formatting could be done to make it yyyy/mm/dd HH:MM
-  // return `${date_london} ${date_london_time}`;
   return `${date_london}`;
 };
 


### PR DESCRIPTION
# Pull Request

## Description

Moved buttons and updated the date format. 

There might be an issue with deployment code because I created a variable called `options` when updating the date format in `utils.ts` and typescript in didn't seem to like that. 

The zoom in and out button still needs to be moved. 

Fixes #219 & #220 

Previous: 

![Screenshot 2022-09-22 at 15 54 35](https://user-images.githubusercontent.com/86949265/191766127-75b49f71-f36f-4ad0-984c-f58fd951ae25.png)


Design Suggestion: 

![](https://user-images.githubusercontent.com/34686298/190421222-d8ae3d2b-ddb8-4e37-bfe2-99e33206085b.png)



New: 

<img width="1673" alt="Screenshot 2022-09-22 at 15 43 55" src="https://user-images.githubusercontent.com/86949265/191765489-20cc8a83-2eb2-41c4-9024-8ec763177dc7.png">

## How Has This Been Tested?

This was tested visually by running the code locally. 

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
