### PR TITLE
Feat/236 fix date on pv remix pop up

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "editor.acceptSuggestionOnCommitCharacter": false,
-  "editor.defaultFormatter": "rvest.vs-code-prettier-eslint"
-}

--- a/apps/nowcasting-app/.gitignore
+++ b/apps/nowcasting-app/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # Sentry
 .sentryclirc
+
+# vscode 
+/.vscode/

--- a/apps/nowcasting-app/.vscode/settings.json
+++ b/apps/nowcasting-app/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.defaultFormatter": "rvest.vs-code-prettier-eslint"
-}

--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -9,7 +9,7 @@ import {
   ResponsiveContainer,
   Tooltip
 } from "recharts";
-import { convertISODateStringToLondonTime, formatISODateStringHuman } from "../utils";
+import { convertISODateStringToLondonTime, formatISODateStringHumanNumbersOnly } from "../utils";
 import { theme } from "../../tailwind.config";
 const yellow = theme.extend.colors["ocf-yellow"].DEFAULT;
 export type ChartData = {
@@ -217,7 +217,7 @@ const RemixLine: React.FC<RemixLineProps> = ({
                         })}
                       <li className={`flex justify-between pt-4 text-sm text-white font-serif`}>
                         <div>
-                          {formatISODateStringHuman(data?.formatedDate + ":00+00:00")}{" "}
+                          {formatISODateStringHumanNumbersOnly(data?.formatedDate + ":00+00:00")}{" "}
                           </div>
                         <div>MW</div>
                       </li>

--- a/apps/nowcasting-app/components/utils.ts
+++ b/apps/nowcasting-app/components/utils.ts
@@ -60,6 +60,21 @@ export const formatISODateStringHuman = (date: string) => {
   return `${date_london}`;
 };
 
+export const formatISODateStringHumanNumbersOnly = (date: string) => {
+  // Change date to nice human readable format.
+  // Note that this converts the string to Europe London Time
+  // timezone and seconds are removed
+
+  const d = new Date(date);
+  
+  const date_london = d.toLocaleDateString("en-GB", { timeZone: 'Europe/London' });
+  const date_london_time = d.toLocaleTimeString("en-GB", { timeZone: "Europe/London" }).slice(0, 5);
+
+  // further formatting could be done to make it yyyy/mm/dd HH:MM
+  return `${date_london} ${date_london_time}`;
+};
+
+
 export const MWtoGW = (MW: number) => {
   return (MW / 1000).toFixed(1);
 };


### PR DESCRIPTION
# Pull Request

## Description

Creates a new date function called `formatISODateStringHumanNumbersOnly` in `utils.ts` to create a date for the pv-remix-chart pop-up graphic that's only in numbers. The date got changed yesterday when I updated the date format for the map. 

The `formatISODateStringHuman` function now creates the date in words: `Friday, 23 September 2022` that's on the map. That hasn't changed. 

There were also two random `vscode` files that got pushed to the development branch (remnants of my linting saga), and I've deleted those on this branch. 

Fixes #236

What it looked like this morning:  

<img width="351" alt="Screenshot 2022-09-23 at 10 08 03" src="https://user-images.githubusercontent.com/86949265/191949794-cd29bc23-f6aa-4d94-8351-fe90b8dba3d3.png">

What it looks like now: 

<img width="269" alt="Screenshot 2022-09-22 at 12 33 32" src="https://user-images.githubusercontent.com/86949265/191949839-ee337cbc-b24f-4a7a-9722-9bfb59e2c745.png">

Would be great to just check that both dates are working. 

## How Has This Been Tested?

Tested visually by running the code locally.

- [ ] Yes


## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
