### PR TITLE
Feat/217 change close button

### DIFF
--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/forecast-header-gsp.tsx
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/forecast-header-gsp.tsx
@@ -16,14 +16,16 @@ const ForecastHeaderGSP: React.FC<ForecastHeaderGSPProps> = ({ title, children, 
       </div>
       <div className="flex-[2] m-auto">
         <p className="text-lg text-center align-middle m-auto mx-2">{children}</p>
-      </div>
+        </div>
       <button
         type="button"
         onClick={onClose}
-        className="font-bold inline-flex items-center  px-3 ml-2 text-lg m text-black bg-ocf-yellow  hover:bg-ocf-yellow focus:z-10 focus:bg-ocf-yellow focus:text-black h-full"
+        className="font-bold inline-flex items-center px-3 ml-2 text-2xl m text-black bg-ocf-yellow  hover:bg-ocf-yellow focus:z-10 focus:bg-ocf-yellow focus:text-black h-full"
       >
-        Close
-      </button>
+        <span className="material-symbols-outlined font-extrabold">
+      close
+      </span>
+        </button>
     </div>
   );
 };

--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -192,6 +192,7 @@ const RemixLine: React.FC<RemixLineProps> = ({
               content={({ payload, label }) => {
                 const data = payload && payload[0]?.payload;
                 if (!data) return <div></div>;
+
                 return (
                   <div className="p-2 bg-mapbox-black bg-opacity-70 shadow">
                     <ul className="">
@@ -201,7 +202,7 @@ const RemixLine: React.FC<RemixLineProps> = ({
                           if (name === "formatedDate") return null;
                           return (
                             <li
-                              className={`font-sans`}
+                              className={`font-sans textClass`}
                               key={`item-${name}`}
                               style={{ color: toolTipColors[name] }}
                             >

--- a/apps/nowcasting-app/pages/_document.tsx
+++ b/apps/nowcasting-app/pages/_document.tsx
@@ -10,6 +10,7 @@ class MyDocument extends Document {
             rel="stylesheet"
           />
           <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"/>
           <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js" defer></script>
         </Head>
         <body className="h-full">


### PR DESCRIPTION
# Pull Request

## Description

Added an icon to the close button on the GSP forecast header. Icon is from google icons, and I added the stylesheet link in the `_document.ts` file. 
Also added the source code pro font to the stylesheets in the `_document.ts` file. 

![Screenshot 2022-09-23 at 17 15 39](https://user-images.githubusercontent.com/86949265/191994785-7f73d829-6211-46f9-914b-031b6859c916.png)

Fixes #217 

## How Has This Been Tested?

Tested visually by running it locally. 

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
