### PR TITLE
feat/217 fixing close button 

### DIFF
--- a/apps/nowcasting-app/.gitignore
+++ b/apps/nowcasting-app/.gitignore
@@ -36,5 +36,3 @@ yarn-error.log*
 # Sentry
 .sentryclirc
 
-# vscode 
-/.vscode/

--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/forecast-header-gsp.tsx
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/forecast-header-gsp.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { CloseButtonIcon } from "../../icons";
 
 type ForecastHeaderGSPProps = {
   title: string;
@@ -17,12 +18,13 @@ const ForecastHeaderGSP: React.FC<ForecastHeaderGSPProps> = ({ title, children, 
       <div className="flex-[2] m-auto">
         <p className="text-lg text-center align-middle m-auto mx-2">{children}</p>
       </div>
+      <div></div>
       <button
         type="button"
         onClick={onClose}
-        className="font-bold inline-flex items-center px-3 ml-2 text-2xl m text-black bg-ocf-yellow  hover:bg-ocf-yellow focus:z-10 focus:bg-ocf-yellow focus:text-black h-full"
+        className="font-bold items-center px-3 ml-2 text-2xl m text-black bg-ocf-yellow  hover:bg-ocf-yellow focus:z-10 focus:bg-ocf-yellow focus:text-black h-full"
       >
-        <span className="material-symbols-outlined font-extrabold">close</span>
+        <CloseButtonIcon />
       </button>
     </div>
   );

--- a/apps/nowcasting-app/components/icons.tsx
+++ b/apps/nowcasting-app/components/icons.tsx
@@ -5,6 +5,10 @@ type LegendLineGraphIconProps = {
   dashed?: boolean;
 };
 
+type CloseButtonIconProps = {
+  className?: string;
+};
+
 export const LegendLineGraphIcon: React.FC<LegendLineGraphIconProps> = ({
   className,
   dashed = false
@@ -22,6 +26,22 @@ export const LegendLineGraphIcon: React.FC<LegendLineGraphIconProps> = ({
       strokeWidth={2}
       stroke="currentColor"
       strokeDasharray={dashed ? "3 3" : "0"}
+    />
+  </svg>
+);
+
+export const CloseButtonIcon: React.FC<CloseButtonIconProps> = ({ className }) => (
+  <svg
+    className={className}
+    width="3rem"
+    height="3rem"
+    viewBox="0 0 16 16"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      stroke="currentColor"
+      strokeWidth={0.5}
+      d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"
     />
   </svg>
 );


### PR DESCRIPTION
imported close icon into forecast-header-gsp and added to button

# Pull Request

## Description

Updated button with an svg icon and saved in `icons.tsx`. 
I then imported the icon into the `forecast-header-gsp.tsx` file and added the icon to the close button. 

It should look like this in development: 

<img width="754" alt="Screenshot 2022-09-26 at 14 02 57" src="https://user-images.githubusercontent.com/86949265/192271485-c0ec5c46-c5dc-4da2-a2e6-98c54edb1c0c.png">


Fixes #217 

## How Has This Been Tested?

Tested visually by running locally. 

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
