### PR TITLE
add 28 and 36 for GSP levels

### DIFF
--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
@@ -9,7 +9,7 @@ import Spinner from "../../spinner";
 // We want to have the ymax of the graph to be related to the capacity of the GspPvRemixChart
 // If we use the raw values, the graph looks funny, i.e y major ticks are 0 100 232
 // So, we round these up to the following numbers
-const yMax_levels = [3, 9, 20, 45, 60, 80, 100, 120, 160, 200, 240, 300, 320, 360, 400, 450, 600];
+const yMax_levels = [3, 9, 20, 28, 36, 45, 60, 80, 100, 120, 160, 200, 240, 300, 320, 360, 400, 450, 600];
 
 const GspPvRemixChart: FC<{
   gspId: number;

--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
@@ -9,7 +9,9 @@ import Spinner from "../../spinner";
 // We want to have the ymax of the graph to be related to the capacity of the GspPvRemixChart
 // If we use the raw values, the graph looks funny, i.e y major ticks are 0 100 232
 // So, we round these up to the following numbers
-const yMax_levels = [3, 9, 20, 28, 36, 45, 60, 80, 100, 120, 160, 200, 240, 300, 320, 360, 400, 450, 600];
+const yMax_levels = [
+  3, 9, 20, 28, 36, 45, 60, 80, 100, 120, 160, 200, 240, 300, 320, 360, 400, 450, 600
+];
 
 const GspPvRemixChart: FC<{
   gspId: number;


### PR DESCRIPTION
# Pull Request

## Description

Add extra GSP maximum heights

added
- 28
- 36
so now all are
const yMax_levels = [3, 9, 20, 28, 36, 45, 60, 80, 100, 120, 160, 200, 240, 300, 320, 360, 400, 450, 600];

![Screenshot 2022-09-27 at 11 56 55](https://user-images.githubusercontent.com/34686298/192508000-fbb51cb2-603a-4ced-bbda-0311dd7e30f6.png)


Helps with #150 

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
