### PR TITLE
change forecast creation time to YYYY/MM/DD HH:MM #242

### DIFF
--- a/apps/nowcasting-app/components/side-layout/side-footer/index.tsx
+++ b/apps/nowcasting-app/components/side-layout/side-footer/index.tsx
@@ -1,6 +1,6 @@
 import useGlobalState from "../../globalState";
 import Tooltip from "../../tooltip";
-import { classNames, formatISODateStringHuman } from "../../utils";
+import { classNames, formatISODateStringHumanNumbersOnly } from "../../utils";
 import ProfileDropDown from "./profile-dropdown";
 import { OCFlogo } from "../../logo";
 import Link from "next/link";
@@ -23,7 +23,7 @@ const chartInfo = (forecastCreationTime?: string) => (
         generation between 16:30 to 17:00.
       </li>
       <li>The Y axis units are in MW, for the national and GSP plots. </li>
-      <li> OCF Forecast Creation Time: {formatISODateStringHuman(forecastCreationTime || "")}</li>
+      <li> OCF Forecast Creation Time: {formatISODateStringHumanNumbersOnly(forecastCreationTime || "")}</li>
     </ul>
   </div>
 );

--- a/apps/nowcasting-app/components/side-layout/side-footer/index.tsx
+++ b/apps/nowcasting-app/components/side-layout/side-footer/index.tsx
@@ -23,7 +23,11 @@ const chartInfo = (forecastCreationTime?: string) => (
         generation between 16:30 to 17:00.
       </li>
       <li>The Y axis units are in MW, for the national and GSP plots. </li>
-      <li> OCF Forecast Creation Time: {formatISODateStringHumanNumbersOnly(forecastCreationTime || "")}</li>
+      <li>
+        {" "}
+        OCF Forecast Creation Time:{" "}
+        {formatISODateStringHumanNumbersOnly(forecastCreationTime || "")}
+      </li>
     </ul>
   </div>
 );


### PR DESCRIPTION
# Pull Request

## Description

Change forecast creation time to `YYYY/MM/DD HH:MM`

Before
![Screenshot 2022-09-28 at 09 36 34](https://user-images.githubusercontent.com/34686298/192731284-2cfe19ca-2cee-42c0-b769-342b3460ed09.png)


Now:

<img width="433" alt="Screenshot 2022-09-28 at 09 33 50" src="https://user-images.githubusercontent.com/34686298/192731165-0dd78883-1ac6-4509-b66f-a076e42249ed.png">


Fixes #242 

## How Has This Been Tested?

run locally

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
