### PR TITLE
#263: add env var to constant.ts for API_PREFIX

### DIFF
--- a/apps/nowcasting-app/constant.ts
+++ b/apps/nowcasting-app/constant.ts
@@ -1,4 +1,4 @@
-export const API_PREFIX = "https://api-dev.nowcasting.io/v0";
+export const API_PREFIX = process.env.NEXT_PUBLIC_API_PREFIX || "https://api-dev.nowcasting.io/v0";
 export const MAX_POWER_GENERATED = 500;
 export const MAX_NATIONAL_GENERATION_MW = 12000;
 


### PR DESCRIPTION
# Pull Request

## Description

Pretty self explanatory, added in an ENV VAR to set the API prefix for different environments.

**NB env variables should be in Vercel now too, just need double checking in Prod when Development gets merged.**

Fixes #263 

## How Has This Been Tested?

Changed the env var in dev from `api-dev` to `api-pro` and back respectively, seeing the graphs update on restart of dev server.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
