### PR TITLE
updating GSP pv remix chart header

### DIFF
--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/forecast-header-gsp.tsx
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/forecast-header-gsp.tsx
@@ -3,26 +3,35 @@ import { CloseButtonIcon } from "../../icons";
 
 type ForecastHeaderGSPProps = {
   title: string;
+  mwpercent: number;
   onClose?: () => void;
 };
 
-const ForecastHeaderGSP: React.FC<ForecastHeaderGSPProps> = ({ title, children, onClose }) => {
+const ForecastHeaderGSP: React.FC<ForecastHeaderGSPProps> = ({
+  title,
+  mwpercent,
+  children,
+  onClose
+}) => {
   return (
-    <div id="x" className={"flex content-between flex-wrap mt-6 bg-ocf-yellow bg-opacity-60 h-12"}>
+    <div id="x" className={"flex content-between flex-wrap mt-6 bg-ocf-gray-800 h-12"}>
       <div
-        className={`bg-white text-black lg:text-2xl md:text-lg text-sm font-black  p-4 py-2  flex-[2]`}
+        className={`bg-ocf-gray-800 text-white lg:text-xl md:text-lg text-med font-black flex-[2] ml-5 m-auto py-2`}
       >
         {title}
-        <span className={`text-base text-ocf-gray-900 ml-5`}>MW</span>
       </div>
-      <div className="flex-[2] m-auto">
-        <p className="text-lg text-center align-middle m-auto mx-2">{children}</p>
+      <div className="flex flex-row justify-between flex-[1] m-auto px-5">
+        <div className="lg:text-lg md:text-lg pr-5">
+          <span className="font-semibold text-med text-ocf-yellow-500">{mwpercent}</span>
+          <span className="text-xs text-ocf-gray-300">%</span>
+        </div>
+        <div>{children}</div>
       </div>
       <div></div>
       <button
         type="button"
         onClick={onClose}
-        className="font-bold items-center px-3 ml-2 text-2xl m text-black bg-ocf-yellow  hover:bg-ocf-yellow focus:z-10 focus:bg-ocf-yellow focus:text-black h-full"
+        className="font-bold items-center px-3 ml-2 text-2xl m text-white bg-ocf-gray-800 hover:bg-ocf-gray-700 focus:z-10 focus:text-white h-full"
       >
         <CloseButtonIcon />
       </button>

--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
@@ -58,11 +58,18 @@ const GspPvRemixChart: FC<{
   return (
     <>
       <div className="bg-black">
-        <ForecastHeaderGSP onClose={close} title={gspInfo?.regionName || ""}>
-          {Math.round(pvPercentage)}% |{" "}
-          {Math.round(forcastAtSelectedTime.expectedPowerGenerationMegawatts || 0)} /{" "}
-          {gspInfo?.installedCapacityMw}
-          <span className=" ml-2 font-bold">MW</span>
+        <ForecastHeaderGSP
+          onClose={close}
+          title={gspInfo?.regionName || ""}
+          mwpercent={Math.round(pvPercentage)}
+        >
+          <span className="font-semibold lg:text-lg md:text-lg text-med text-ocf-yellow-500">
+            {Math.round(forcastAtSelectedTime.expectedPowerGenerationMegawatts || 0)}
+          </span>
+          <span className="font-semibold lg:text-lg md:text-lg text-med text-white">
+            /{gspInfo?.installedCapacityMw}
+          </span>
+          <span className="text-xs text-ocf-gray-300">MW</span>
         </ForecastHeaderGSP>
       </div>
 

--- a/apps/nowcasting-app/components/icons.tsx
+++ b/apps/nowcasting-app/components/icons.tsx
@@ -32,16 +32,16 @@ export const LegendLineGraphIcon: React.FC<LegendLineGraphIconProps> = ({
 
 export const CloseButtonIcon: React.FC<CloseButtonIconProps> = ({ className }) => (
   <svg
-    className={className}
-    width="3rem"
-    height="3rem"
-    viewBox="0 0 16 16"
     xmlns="http://www.w3.org/2000/svg"
+    version="1.1"
+    width="2rem"
+    height="2rem"
+    viewBox="0 0 24 24"
   >
     <path
-      stroke="currentColor"
       strokeWidth={0.5}
-      d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"
+      d="M20.030 5.030l-1.061-1.061-6.97 6.97-6.97-6.97-1.061 1.061 6.97 6.97-6.97 6.97 1.061 1.061 6.97-6.97 6.97 6.97 1.061-1.061-6.97-6.97 6.97-6.97z"
+      fill="white"
     />
   </svg>
 );

--- a/apps/nowcasting-app/tailwind.config.js
+++ b/apps/nowcasting-app/tailwind.config.js
@@ -1,6 +1,21 @@
 const defaultTheme = require("tailwindcss/defaultTheme");
 
 module.exports = {
+  theme: {
+    fontWeight: {
+      hairline: 100,
+      'extra-light': 100,
+      thin: 200,
+      light: 300,
+      normal: 400,
+      medium: 500,
+      semibold: 600,
+      bold: 700,
+      extrabold: 800,
+      'extra-bold': 800,
+      black: 900,
+    }
+  },
   content: ["./pages/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
   safelist: [
     "bg-ocf-yellow",


### PR DESCRIPTION
# Pull Request

## Description

Updates the GSP pv remix chart header per the [Developer Handoff design](https://www.figma.com/file/5RmuNt9H2398bXDGmPoz6V/Developer-Handoff?node-id=0%3A1). 
The background for the header is `OCF-gray-800`. 

Main changes are
- changing the `X` svg in the close button to have flat and not rounded edges
- splitting the megawatt percentage and mws/mw capacity into two separate `divs` and adding a `mwpercent` prop to the the `ForecastHeaderGSPProps` type
- adding font-weights to the` tailwind.config.js` file to see if the numbers in the header cold be "semi-bold" and not "bold". 

On the expanded screen, I think the two mw numbers look too far apart, so would like a second opinion. 

Fixes #265 

## How Has This Been Tested?
This has been tested visually by running the code locally. 

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
