### PR TITLE
Feat/256 update national forecast header

### DIFF
--- a/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
+++ b/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
@@ -2,22 +2,38 @@ import React from "react";
 import { theme } from "../../../tailwind.config";
 const yellow = theme.extend.colors["ocf-yellow"].DEFAULT;
 
-const PVNumber: React.FC<{ pv: string; subTitle: string; color?: string }> = ({
+const PVNumber: React.FC<{ pv: string; time: string; color?: string }> = ({
   pv,
-  subTitle,
+  time,
   color = yellow
 }) => {
   return (
     <div className="flex-[1] m-auto">
       <div className="">
+        <p className="">
+          <svg
+            viewBox="0 0 48 48"
+            width="2rem"
+            height="2rem"
+            xmlns="http://www.w3.org/2000/svg"
+            fill-rule="evenodd"
+            fill="white"
+            clip-rule="evenodd"
+          >
+            <path
+              d="M12 0c6.623 0 12 5.377 12 12s-5.377 12-12 12-12-5.377-12-12 5.377-12 12-12zm0 1c6.071
+             0 11 4.929 11 11s-4.929 11-11 11-11-4.929-11-11 4.929-11 11-11zm0 11h6v1h-7v-9h1v8z"
+            />
+          </svg>
+          {time}
+        </p>
         <p
-          className={`lg:text-xl md:text-lg text-sm font-bold text-center text-${color}`}
+          className={`lg:text-xl md:text-lg text-sm font-semibold text-center text-${color}`}
           style={{ color: color }}
         >
           {pv}
-          <span className=" ml-2 text-white">GW</span>
+          <span className="text-xs text-ocf-gray-300 font-normal">GW</span>
         </p>
-        <p className="text-white whitespace-pre text-center ">{subTitle}</p>
       </div>
     </div>
   );
@@ -41,16 +57,24 @@ const ForecastHeaderUI: React.FC<ForecastHeaderProps> = ({
   forecastNextTimeOnly
 }) => {
   return (
-    <div className={"flex content-between flex-wrap mt-6 h-auto"}>
-      <div
-        className={`bg-white text-black lg:text-2xl md:text-lg text-sm font-black p-4 py-2 flex-[2]`}
-      >
-        National Solar PV <span className={`text-base text-ocf-gray-900 ml-2`}>MW</span>
+    <div className={"flex content-between bg-ocf-gray-800 flex-wrap h-auto"}>
+      <div className={`text-white lg:text-2xl md:text-lg text-sm font-black m-auto ml-5 flex-[2]`}>
+        National
       </div>
-      <PVNumber pv={actualPV} subTitle={`${pvTimeOnly} PVLive`} color="black" />
-      <PVNumber pv={forcastPV} subTitle={`${selectedTimeOnly} Forecast`} />
-      <PVNumber pv={forcastNextPV} subTitle={`${forecastNextTimeOnly} Forecast`} />
-      <div className=" inline-flex items-center h-full m-auto">{children}</div>
+      <PVNumber
+        pv={
+          <div>
+            <span className="text-ocf-yellow font-semibold">{forcastPV}</span>
+            <span className="text-white font-semibold">/</span>
+            {actualPV}
+          </div>
+        }
+        time={`${pvTimeOnly}`}
+        color="black"
+      />
+      {/* <PVNumber pv={forcastPV} time={`${selectedTimeOnly}`} color="ocf-yellow" /> */}
+      <PVNumber pv={forcastNextPV} time={`${forecastNextTimeOnly}`} color="ocf-yellow" />
+      <div className="inline-flex items-center h-full">{children}</div>
     </div>
   );
 };

--- a/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
+++ b/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
@@ -8,7 +8,7 @@ const PVNumber: React.FC<{ pv: string; time: string; color?: string }> = ({
   color = yellow
 }) => {
   return (
-    <div className="flex flex-col m-auto">
+    <div className="flex flex-col m-auto h-10">
       <div className="flex justify-items-start">
         <svg
           viewBox="0 0 32 32"
@@ -27,12 +27,9 @@ const PVNumber: React.FC<{ pv: string; time: string; color?: string }> = ({
         <p className="text-xs">{time}</p>
       </div>
       <div>
-        <p
-          className={`lg:text-xl md:text-lg text-sm font-semibold text-center text-${color}`}
-          style={{ color: color }}
-        >
+        <p className={`text-lg font-semibold text-center text-${color}`} style={{ color: color }}>
           {pv}
-          <span className="text-xs text-ocf-gray-300 font-normal">GW</span>
+          <span className="text-xs text-ocf-gray-300 font-normal"> GW</span>
         </p>
       </div>
     </div>
@@ -57,18 +54,20 @@ const ForecastHeaderUI: React.FC<ForecastHeaderProps> = ({
   forecastNextTimeOnly
 }) => {
   return (
-    <>
+    <div className="flex content-between bg-ocf-gray-800 h-auto">
       <div className="text-white lg:text-2xl md:text-lg text-sm font-black m-auto ml-5 flex justify-evenly">
         National
       </div>
-      <div>
-        <PVNumber pv={`${forcastPV}/${actualPV}`} time={`${pvTimeOnly}`} color="black" />
-      </div>
-      <div>
-        <PVNumber pv={forcastNextPV} time={`${forecastNextTimeOnly}`} color="ocf-yellow" />
+      <div className="flex justify-between flex-2 mt-1 px-5">
+        <div className="pr-10">
+          <PVNumber pv={`${forcastPV}/${actualPV}`} time={`${pvTimeOnly}`} color="black" />
+        </div>
+        <div>
+          <PVNumber pv={forcastNextPV} time={`${forecastNextTimeOnly}`} color="ocf-yellow" />
+        </div>
       </div>
       <div className="inline-flex h-full">{children}</div>
-    </>
+    </div>
   );
 };
 

--- a/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
+++ b/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
@@ -1,8 +1,33 @@
 import React from "react";
 import { theme } from "../../../tailwind.config";
+import { ClockIcon } from "../../icons";
 const yellow = theme.extend.colors["ocf-yellow"].DEFAULT;
 
-const PVNumber: React.FC<{ pv: string; time: string; color?: string }> = ({
+const ForecastWithActualPV: React.FC<{
+  forecast: string;
+  pv: string;
+  time: string;
+  color?: string;
+}> = ({ forecast, pv, time, color = yellow }) => {
+  return (
+    <div className="flex flex-col m-auto h-10">
+      <div className="flex justify-items-start">
+        <ClockIcon />
+        <p className="text-xs">{time}</p>
+      </div>
+      <div>
+        <p className={`text-lg font-semibold text-center text-${color}`} style={{ color: color }}>
+          {forecast}
+          <span className="text-ocf-gray-300">/</span>
+          <span className="text-black">{pv}</span>
+          <span className="text-xs text-ocf-gray-300 font-normal"> GW</span>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+const NextForecast: React.FC<{ pv: string; time: string; color?: string }> = ({
   pv,
   time,
   color = yellow
@@ -10,20 +35,7 @@ const PVNumber: React.FC<{ pv: string; time: string; color?: string }> = ({
   return (
     <div className="flex flex-col m-auto h-10">
       <div className="flex justify-items-start">
-        <svg
-          viewBox="0 0 32 32"
-          width="16"
-          height="16"
-          xmlns="http://www.w3.org/2000/svg"
-          fill-rule="evenodd"
-          fill="white"
-          clip-rule="evenodd"
-        >
-          <path
-            d="M12 0c6.623 0 12 5.377 12 12s-5.377 12-12 12-12-5.377-12-12 5.377-12 12-12zm0 1c6.071
-             0 11 4.929 11 11s-4.929 11-11 11-11-4.929-11-11 4.929-11 11-11zm0 11h6v1h-7v-9h1v8z"
-          />
-        </svg>
+        <ClockIcon />
         <p className="text-xs">{time}</p>
       </div>
       <div>
@@ -60,10 +72,15 @@ const ForecastHeaderUI: React.FC<ForecastHeaderProps> = ({
       </div>
       <div className="flex justify-between flex-2 mt-1 px-5">
         <div className="pr-10">
-          <PVNumber pv={`${forcastPV}/${actualPV}`} time={`${pvTimeOnly}`} color="black" />
+          <ForecastWithActualPV
+            forecast={`${forcastPV}`}
+            pv={`${actualPV}`}
+            time={`${pvTimeOnly}`}
+            color="ocf-yellow"
+          />
         </div>
         <div>
-          <PVNumber pv={forcastNextPV} time={`${forecastNextTimeOnly}`} color="ocf-yellow" />
+          <NextForecast pv={forcastNextPV} time={`${forecastNextTimeOnly}`} color="ocf-yellow" />
         </div>
       </div>
       <div className="inline-flex h-full">{children}</div>

--- a/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
+++ b/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
@@ -8,25 +8,25 @@ const PVNumber: React.FC<{ pv: string; time: string; color?: string }> = ({
   color = yellow
 }) => {
   return (
-    <div className="flex-[1] m-auto">
-      <div className="">
-        <p className="">
-          <svg
-            viewBox="0 0 48 48"
-            width="2rem"
-            height="2rem"
-            xmlns="http://www.w3.org/2000/svg"
-            fill-rule="evenodd"
-            fill="white"
-            clip-rule="evenodd"
-          >
-            <path
-              d="M12 0c6.623 0 12 5.377 12 12s-5.377 12-12 12-12-5.377-12-12 5.377-12 12-12zm0 1c6.071
+    <div className="flex flex-col m-auto">
+      <div className="flex justify-items-start">
+        <svg
+          viewBox="0 0 32 32"
+          width="16"
+          height="16"
+          xmlns="http://www.w3.org/2000/svg"
+          fill-rule="evenodd"
+          fill="white"
+          clip-rule="evenodd"
+        >
+          <path
+            d="M12 0c6.623 0 12 5.377 12 12s-5.377 12-12 12-12-5.377-12-12 5.377-12 12-12zm0 1c6.071
              0 11 4.929 11 11s-4.929 11-11 11-11-4.929-11-11 4.929-11 11-11zm0 11h6v1h-7v-9h1v8z"
-            />
-          </svg>
-          {time}
-        </p>
+          />
+        </svg>
+        <p className="text-xs">{time}</p>
+      </div>
+      <div>
         <p
           className={`lg:text-xl md:text-lg text-sm font-semibold text-center text-${color}`}
           style={{ color: color }}
@@ -57,25 +57,18 @@ const ForecastHeaderUI: React.FC<ForecastHeaderProps> = ({
   forecastNextTimeOnly
 }) => {
   return (
-    <div className={"flex content-between bg-ocf-gray-800 flex-wrap h-auto"}>
-      <div className={`text-white lg:text-2xl md:text-lg text-sm font-black m-auto ml-5 flex-[2]`}>
+    <>
+      <div className="text-white lg:text-2xl md:text-lg text-sm font-black m-auto ml-5 flex justify-evenly">
         National
       </div>
-      <PVNumber
-        pv={
-          <div>
-            <span className="text-ocf-yellow font-semibold">{forcastPV}</span>
-            <span className="text-white font-semibold">/</span>
-            {actualPV}
-          </div>
-        }
-        time={`${pvTimeOnly}`}
-        color="black"
-      />
-      {/* <PVNumber pv={forcastPV} time={`${selectedTimeOnly}`} color="ocf-yellow" /> */}
-      <PVNumber pv={forcastNextPV} time={`${forecastNextTimeOnly}`} color="ocf-yellow" />
-      <div className="inline-flex items-center h-full">{children}</div>
-    </div>
+      <div>
+        <PVNumber pv={`${forcastPV}/${actualPV}`} time={`${pvTimeOnly}`} color="black" />
+      </div>
+      <div>
+        <PVNumber pv={forcastNextPV} time={`${forecastNextTimeOnly}`} color="ocf-yellow" />
+      </div>
+      <div className="inline-flex h-full">{children}</div>
+    </>
   );
 };
 

--- a/apps/nowcasting-app/components/icons.tsx
+++ b/apps/nowcasting-app/components/icons.tsx
@@ -9,6 +9,10 @@ type CloseButtonIconProps = {
   className?: string;
 };
 
+type ClockIconProps = {
+  className?: string;
+};
+
 export const LegendLineGraphIcon: React.FC<LegendLineGraphIconProps> = ({
   className,
   dashed = false
@@ -42,6 +46,23 @@ export const CloseButtonIcon: React.FC<CloseButtonIconProps> = ({ className }) =
       strokeWidth={0.5}
       d="M20.030 5.030l-1.061-1.061-6.97 6.97-6.97-6.97-1.061 1.061 6.97 6.97-6.97 6.97 1.061 1.061 6.97-6.97 6.97 6.97 1.061-1.061-6.97-6.97 6.97-6.97z"
       fill="white"
+    />
+  </svg>
+);
+
+export const ClockIcon: React.FC<ClockIconProps> = ({ className }) => (
+  <svg
+    viewBox="0 0 32 32"
+    width="16"
+    height="16"
+    xmlns="http://www.w3.org/2000/svg"
+    fill-rule="evenodd"
+    fill="white"
+    clip-rule="evenodd"
+  >
+    <path
+      d="M12 0c6.623 0 12 5.377 12 12s-5.377 12-12 12-12-5.377-12-12 5.377-12 12-12zm0 1c6.071
+      0 11 4.929 11 11s-4.929 11-11 11-11-4.929-11-11 4.929-11 11-11zm0 11h6v1h-7v-9h1v8z"
     />
   </svg>
 );

--- a/apps/nowcasting-app/components/play-button/ui.tsx
+++ b/apps/nowcasting-app/components/play-button/ui.tsx
@@ -8,17 +8,17 @@ type UiProps = {
 const Ui: React.FC<UiProps> = ({ onClick, isPlaying }) => {
   return (
     <button
-      className="items-center w-16 h-12 px-3 text-lg m text-black bg-ocf-yellow  hover:bg-ocf-yellow focus:z-10 focus:bg-ocf-yellow "
+      className="items-center w-12 h-12 text-lg m text-black bg-ocf-yellow  hover:bg-ocf-yellow focus:z-10 focus:bg-ocf-yellow "
       onClick={() => {
         onClick();
       }}
     >
       {!isPlaying ? (
-        <svg viewBox="0 0 24 24" fill="currentColor" height="3rem" width="3rem">
+        <svg viewBox="0 0 20 24" fill="currentColor" height="3rem" width="3rem">
           <path d="M7 6v12l10-6z" />
         </svg>
       ) : (
-        <svg fill="none" viewBox="0 0 24 24" height="3rem" width="3rem">
+        <svg fill="none" viewBox="0 0 22 24" height="3rem" width="3rem">
           <path fill="currentColor" d="M11 7H8v10h3V7zM13 17h3V7h-3v10z" />
         </svg>
       )}


### PR DESCRIPTION
# Pull Request

## Description

Updates the National forecast header. 
The branch to view is `feat/256-update-national-forecast-header`. 

The `ClockIcon` that I added doesn't completely align with the time in the header as shown in the design suggestion below, so I'd like to know if it looks ok. 

In changing the design, I removed the previous `PVNumber` variable and replaced it with `ForecastWithActualPV` and `NextForecast`. 

Previous: 

![Screenshot 2022-09-29 at 12 04 54](https://user-images.githubusercontent.com/86949265/193003437-a175ca1f-4beb-4661-a8a0-e797bd8a808f.png)

Design suggestion: 

<img width="549" alt="Screenshot 2022-10-06 at 23 13 12" src="https://user-images.githubusercontent.com/86949265/194419646-c3bb1620-7865-4251-8227-ac0dca5b3fec.png">

Updated:
 
<img width="754" alt="Screenshot 2022-10-13 at 18 48 42" src="https://user-images.githubusercontent.com/86949265/195657057-6339fd38-84d7-4323-ae9c-6e6ac9dc707a.png">


Fixes #256 

## How Has This Been Tested?

This was visually tested by running the code locally. 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
