### PR TITLE
266/add tooltip labels national forecast header

### DIFF
--- a/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
+++ b/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
@@ -20,7 +20,7 @@ const ForecastWithActualPV: React.FC<{
       <div>
         <ForecastLabel
           tip={
-            <div className="w-32">
+            <div className="w-36">
               <p>{tip}</p>
             </div>
           }
@@ -51,7 +51,7 @@ const NextForecast: React.FC<{ pv: string; tip: string; time: string; color?: st
       </div>
       <ForecastLabel
         tip={
-          <div className="w-24">
+          <div className="w-22">
             <p>{tip}</p>
           </div>
         }
@@ -94,7 +94,7 @@ const ForecastHeaderUI: React.FC<ForecastHeaderProps> = ({
           <ForecastWithActualPV
             forecast={`${forcastPV}`}
             pv={`${actualPV}`}
-            tip={`Nowcast / Actual PV`}
+            tip={`Nowcasting / Actual PV`}
             time={`${pvTimeOnly}`}
             color="ocf-yellow"
           />
@@ -103,7 +103,7 @@ const ForecastHeaderUI: React.FC<ForecastHeaderProps> = ({
           <NextForecast
             pv={forcastNextPV}
             time={`${forecastNextTimeOnly}`}
-            tip={`Next Nowcast`}
+            tip={`Nowcasting`}
             color="ocf-yellow"
           />
         </div>

--- a/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
+++ b/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
@@ -1,14 +1,16 @@
 import React from "react";
 import { theme } from "../../../tailwind.config";
 import { ClockIcon } from "../../icons";
+import ForecastLabel from "../../national_forecast_labels";
 const yellow = theme.extend.colors["ocf-yellow"].DEFAULT;
 
 const ForecastWithActualPV: React.FC<{
   forecast: string;
   pv: string;
   time: string;
+  tip: string;
   color?: string;
-}> = ({ forecast, pv, time, color = yellow }) => {
+}> = ({ forecast, pv, time, tip, color = yellow }) => {
   return (
     <div className="flex flex-col m-auto h-10">
       <div className="flex justify-items-start">
@@ -16,20 +18,29 @@ const ForecastWithActualPV: React.FC<{
         <p className="text-xs">{time}</p>
       </div>
       <div>
-        <p className={`text-lg font-semibold text-center text-${color}`} style={{ color: color }}>
-          {forecast}
-          <span className="text-ocf-gray-300">/</span>
-          <span className="text-black">{pv}</span>
-          <span className="text-xs text-ocf-gray-300 font-normal"> GW</span>
-        </p>
+        <ForecastLabel
+          tip={
+            <div className="w-32">
+              <p>{tip}</p>
+            </div>
+          }
+        >
+          <p className={`text-lg font-semibold text-center text-${color}`} style={{ color: color }}>
+            {forecast}
+            <span className="text-ocf-gray-300">/</span>
+            <span className="text-black">{pv}</span>
+            <span className="text-xs text-ocf-gray-300 font-normal"> GW</span>
+          </p>
+        </ForecastLabel>
       </div>
     </div>
   );
 };
 
-const NextForecast: React.FC<{ pv: string; time: string; color?: string }> = ({
+const NextForecast: React.FC<{ pv: string; tip: string; time: string; color?: string }> = ({
   pv,
   time,
+  tip,
   color = yellow
 }) => {
   return (
@@ -38,12 +49,20 @@ const NextForecast: React.FC<{ pv: string; time: string; color?: string }> = ({
         <ClockIcon />
         <p className="text-xs">{time}</p>
       </div>
-      <div>
-        <p className={`text-lg font-semibold text-center text-${color}`} style={{ color: color }}>
-          {pv}
-          <span className="text-xs text-ocf-gray-300 font-normal"> GW</span>
-        </p>
-      </div>
+      <ForecastLabel
+        tip={
+          <div className="w-24">
+            <p>{tip}</p>
+          </div>
+        }
+      >
+        <div>
+          <p className={`text-lg font-semibold text-center text-${color}`} style={{ color: color }}>
+            {pv}
+            <span className="text-xs text-ocf-gray-300 font-normal"> GW</span>
+          </p>
+        </div>
+      </ForecastLabel>
     </div>
   );
 };
@@ -75,12 +94,18 @@ const ForecastHeaderUI: React.FC<ForecastHeaderProps> = ({
           <ForecastWithActualPV
             forecast={`${forcastPV}`}
             pv={`${actualPV}`}
+            tip={`Nowcast / Actual PV`}
             time={`${pvTimeOnly}`}
             color="ocf-yellow"
           />
         </div>
         <div>
-          <NextForecast pv={forcastNextPV} time={`${forecastNextTimeOnly}`} color="ocf-yellow" />
+          <NextForecast
+            pv={forcastNextPV}
+            time={`${forecastNextTimeOnly}`}
+            tip={`Next Nowcast`}
+            color="ocf-yellow"
+          />
         </div>
       </div>
       <div className="inline-flex h-full">{children}</div>

--- a/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
+++ b/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
@@ -51,7 +51,7 @@ const NextForecast: React.FC<{ pv: string; tip: string; time: string; color?: st
       </div>
       <ForecastLabel
         tip={
-          <div className="w-24">
+          <div className="w-28">
             <p>{tip}</p>
           </div>
         }
@@ -103,7 +103,7 @@ const ForecastHeaderUI: React.FC<ForecastHeaderProps> = ({
           <NextForecast
             pv={forcastNextPV}
             time={`${forecastNextTimeOnly}`}
-            tip={`OCF Forecast`}
+            tip={`Next OCF Forecast`}
             color="ocf-yellow"
           />
         </div>

--- a/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
+++ b/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
@@ -51,7 +51,7 @@ const NextForecast: React.FC<{ pv: string; tip: string; time: string; color?: st
       </div>
       <ForecastLabel
         tip={
-          <div className="w-22">
+          <div className="w-24">
             <p>{tip}</p>
           </div>
         }
@@ -94,7 +94,7 @@ const ForecastHeaderUI: React.FC<ForecastHeaderProps> = ({
           <ForecastWithActualPV
             forecast={`${forcastPV}`}
             pv={`${actualPV}`}
-            tip={`Nowcasting / Actual PV`}
+            tip={`OCF Forecast / PV Live`}
             time={`${pvTimeOnly}`}
             color="ocf-yellow"
           />
@@ -103,7 +103,7 @@ const ForecastHeaderUI: React.FC<ForecastHeaderProps> = ({
           <NextForecast
             pv={forcastNextPV}
             time={`${forecastNextTimeOnly}`}
-            tip={`Nowcasting`}
+            tip={`OCF Forecast`}
             color="ocf-yellow"
           />
         </div>

--- a/apps/nowcasting-app/components/national_forecast_labels.tsx
+++ b/apps/nowcasting-app/components/national_forecast_labels.tsx
@@ -1,0 +1,34 @@
+type ForecastLabelProps = {
+  tip: string | React.ReactNode;
+  position?: "left" | "right" | "middle";
+  className?: string;
+};
+
+const ForecastLabel: React.FC<ForecastLabelProps> = ({
+  children,
+  tip,
+  position = "left",
+  className
+}) => {
+  const getPositionClass = (position: "left" | "right" | "middle") => {
+    if (position === "left") return "-left-5";
+    if (position === "right") return "-right-3";
+    if (position === "middle") return "";
+  };
+  return (
+    <div className={`relative cursor-default flex group ${className || ""}`}>
+      {children}
+      <div className="absolute flex hidden mt-6 group-hover:flex flex-wrap">
+        <span
+          className={`relative ${getPositionClass(
+            position
+          )} flex top-0 text-center mb-0 mt-2z-10 text-xs px-3 py-1 leading-snug bg-mapbox-black bg-opacity-70 rounded-lg text-white drop-shadow-lg`}
+        >
+          {tip}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default ForecastLabel;


### PR DESCRIPTION
# Pull Request

## Description

Updates the `national forecast header` with two tool tips that label the forecast numbers. These labels were removed from the previous header to make the header a bit sleeker. 

Fixes #266

Would be good to know if these labels are clear. Should I have used `Forecast` instead of `Nowcast` and `PV Live` instead of `Actual PV`?

Previous: 

![](https://user-images.githubusercontent.com/86949265/193003437-a175ca1f-4beb-4661-a8a0-e797bd8a808f.png)

Updated: 
<img width="414" alt="Screenshot 2022-10-14 at 16 15 41" src="https://user-images.githubusercontent.com/86949265/195868926-668bb079-1cc4-4e35-86c3-2e1a8acef9d9.png">

<img width="859" alt="Screenshot 2022-10-14 at 16 16 02" src="https://user-images.githubusercontent.com/86949265/195868987-c88beb9f-692c-42fe-ad58-3080d5a66fea.png">

The tooltip labels match the `pv remix chart pop-up tooltip` in terms of background. This seemed to have a high contrast and was easy to read. 

## How Has This Been Tested?

This was tested visually by running the code locally. 

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code

