### PR TITLE
Fix: legend off-page; national header spacing; unit btn border

### DIFF
--- a/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
+++ b/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
@@ -12,10 +12,10 @@ const ForecastWithActualPV: React.FC<{
   color?: string;
 }> = ({ forecast, pv, time, tip, color = yellow }) => {
   return (
-    <div className="flex flex-col m-auto h-10">
-      <div className="flex justify-items-start">
+    <div className="flex flex-col m-auto h-10 justify-between">
+      <div className="flex items-center mt-0.5">
         <ClockIcon />
-        <p className="text-xs">{time}</p>
+        <p className="text-xs ml-0.5">{time}</p>
       </div>
       <div>
         <ForecastLabel
@@ -25,14 +25,22 @@ const ForecastWithActualPV: React.FC<{
             </div>
           }
         >
-          <p className={`text-lg font-semibold text-center text-${color}`} style={{ color: color }}>
-            {forecast}
-            <span className="text-ocf-gray-300">/</span>
+          <p
+            className={`text-lg font-semibold leading-none text-center text-${color}`}
+            // className={`text-lg font-semibold leading-none mt-0.5 text-center text-${color}`}
+            style={{ color: color }}
+          >
             <span className="text-black">{pv}</span>
+            <span className="text-ocf-gray-300"> / </span>
+            {forecast}
             <span className="text-xs text-ocf-gray-300 font-normal"> GW</span>
           </p>
         </ForecastLabel>
       </div>
+      {/*<div className="flex items-center -ml-[2px]">*/}
+      {/*  <ClockIcon />*/}
+      {/*  <p className="text-xs ml-0.5">{time}</p>*/}
+      {/*</div>*/}
     </div>
   );
 };
@@ -44,10 +52,10 @@ const NextForecast: React.FC<{ pv: string; tip: string; time: string; color?: st
   color = yellow
 }) => {
   return (
-    <div className="flex flex-col m-auto h-10">
-      <div className="flex justify-items-start">
+    <div className="flex flex-col m-auto h-10 justify-between">
+      <div className="flex items-center mt-0.5">
         <ClockIcon />
-        <p className="text-xs">{time}</p>
+        <p className="text-xs ml-0.5">{time}</p>
       </div>
       <ForecastLabel
         tip={
@@ -57,12 +65,20 @@ const NextForecast: React.FC<{ pv: string; tip: string; time: string; color?: st
         }
       >
         <div>
-          <p className={`text-lg font-semibold text-center text-${color}`} style={{ color: color }}>
+          <p
+            className={`text-lg font-semibold leading-none text-center text-${color}`}
+            // className={`text-lg font-semibold leading-none mt-0.5 text-center text-${color}`}
+            style={{ color: color }}
+          >
             {pv}
             <span className="text-xs text-ocf-gray-300 font-normal"> GW</span>
           </p>
         </div>
       </ForecastLabel>
+      {/*<div className="flex items-center -ml-[2px]">*/}
+      {/*  <ClockIcon />*/}
+      {/*  <p className="text-xs ml-0.5">{time}</p>*/}
+      {/*</div>*/}
     </div>
   );
 };
@@ -89,12 +105,12 @@ const ForecastHeaderUI: React.FC<ForecastHeaderProps> = ({
       <div className="text-white lg:text-2xl md:text-lg text-sm font-black m-auto ml-5 flex justify-evenly">
         National
       </div>
-      <div className="flex justify-between flex-2 mt-1 px-5">
-        <div className="pr-10">
+      <div className="flex justify-between flex-2 my-2 px-6">
+        <div className="pr-8">
           <ForecastWithActualPV
             forecast={`${forecastPV}`}
             pv={`${actualPV}`}
-            tip={`OCF Forecast / PV Live`}
+            tip={`PV Live / OCF Forecast`}
             time={`${pvTimeOnly}`}
             color="ocf-yellow"
           />

--- a/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
+++ b/apps/nowcasting-app/components/charts/forecast-header/ui.tsx
@@ -110,7 +110,7 @@ const ForecastHeaderUI: React.FC<ForecastHeaderProps> = ({
           <ForecastWithActualPV
             forecast={`${forecastPV}`}
             pv={`${actualPV}`}
-            tip={`PV Live / OCF Forecast`}
+            tip={`OCF Forecast / PV Live`}
             time={`${pvTimeOnly}`}
             color="ocf-yellow"
           />

--- a/apps/nowcasting-app/components/charts/pv-remix-chart.tsx
+++ b/apps/nowcasting-app/components/charts/pv-remix-chart.tsx
@@ -14,7 +14,7 @@ import useHotKeyControlChart from "../hooks/use-hot-key-control-chart";
 import { LegendLineGraphIcon } from "../icons/icons";
 import { ForecastData } from "../types";
 
-const LegendItem: FC<{ iconClasses: string; label: string; dashed?: boolean }> = ({
+const LegendItem: FC<{ iconClasses: string; label: string; dashed?: boolean; dataKey: string }> = ({
   iconClasses,
   label,
   dashed
@@ -89,7 +89,7 @@ const PvRemixChart: FC<{ date?: string; className?: string }> = ({ className }) 
   };
   return (
     <div className={`flex flex-col flex-1 mb-1 ${className || ""}`}>
-      <div className="flex-grow mb-7">
+      <div className="flex-auto mb-7">
         <ForecastHeader
           pvForecastData={nationalForecastData}
           pvLiveData={pvRealDayInData}
@@ -118,12 +118,30 @@ const PvRemixChart: FC<{ date?: string; className?: string }> = ({ className }) 
           ></GspPvRemixChart>
         )}
       </div>
-      <div className="flex-0 px-3 text-[12px] tracking-wider text-ocf-gray-300 py-2 bg-mapbox-black-500">
-        <div className="flex justify-around">
-          <LegendItem iconClasses={"text-ocf-black"} dashed label={"PV live initial estimate"} />
-          <LegendItem iconClasses={"text-ocf-black"} label={"PV live updated"} />
-          <LegendItem iconClasses={"text-ocf-yellow"} dashed label={"OCF Forecast"} />
-          <LegendItem iconClasses={"text-ocf-yellow"} label={"OCF Final Forecast"} />
+      <div className="flex flex-none flex-row px-4 text-xs tracking-wider text-ocf-gray-300 pt-3 bg-mapbox-black-500 overflow-y-visible">
+        <div className="flex flex-1 justify-around overflow-x-scroll pb-3">
+          <LegendItem
+            iconClasses={"text-ocf-black"}
+            dashed
+            label={"PV live initial estimate"}
+            dataKey={`GENERATION`}
+          />
+          <LegendItem
+            iconClasses={"text-ocf-black"}
+            label={"PV live updated"}
+            dataKey={`GENERATION_UPDATED`}
+          />
+          <LegendItem
+            iconClasses={"text-ocf-yellow"}
+            dashed
+            label={"OCF Forecast"}
+            dataKey={`FORECAST`}
+          />
+          <LegendItem
+            iconClasses={"text-ocf-yellow"}
+            label={"OCF Final Forecast"}
+            dataKey={`PAST_FORECAST`}
+          />
         </div>
       </div>
     </div>

--- a/apps/nowcasting-app/components/map/measuringUnit.tsx
+++ b/apps/nowcasting-app/components/map/measuringUnit.tsx
@@ -42,7 +42,8 @@ const MeasuringUnit = ({
           className={`${buttonClasses} ${
             activeUnit === ActiveUnit.percentage
               ? "text-black bg-ocf-yellow"
-              : "text-white bg-black border-r"
+              : "text-white bg-black"
+            // : "text-white bg-black border-r"
           }  ${isLoading ? "cursor-wait" : ""}`}
         >
           %

--- a/apps/nowcasting-app/components/play-button/ui.tsx
+++ b/apps/nowcasting-app/components/play-button/ui.tsx
@@ -8,14 +8,20 @@ type UiProps = {
 const Ui: React.FC<UiProps> = ({ onClick, isPlaying }) => {
   return (
     <button
-      className="items-center w-12 h-12 text-lg m text-black bg-ocf-yellow  hover:bg-ocf-yellow focus:z-10 focus:bg-ocf-yellow "
+      className="items-center w-14 h-14 text-lg text-black bg-ocf-yellow  hover:bg-ocf-yellow focus:z-10 focus:bg-ocf-yellow "
       onClick={() => {
         onClick();
       }}
     >
       {!isPlaying ? (
-        <svg viewBox="0 0 20 24" fill="currentColor" height="3rem" width="3rem">
-          <path d="M7 6v12l10-6z" />
+        <svg
+          width="3.5rem"
+          height="3.5rem"
+          viewBox="0 0 42 42"
+          fill="currentColor"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M13.75 10.5V31.5L31.25 21L13.75 10.5Z" fill="black" />
         </svg>
       ) : (
         <svg fill="none" viewBox="0 0 22 24" height="3rem" width="3rem">

--- a/apps/nowcasting-app/components/side-layout/index.tsx
+++ b/apps/nowcasting-app/components/side-layout/index.tsx
@@ -9,7 +9,7 @@ const SideLayout: React.FC<SideLayoutProps> = ({ children, className }) => {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <div
-      className={`h-full absolute  z-20 ${className || ""}`}
+      className={`h-full pt-16 absolute top-0 left-0 z-20 ${className || ""}`}
       style={{ width: isOpen ? "90%" : "44%" }}
     >
       <div


### PR DESCRIPTION
# Pull Request

## Description

Hotfix for styling bugs:

- Main bug: layout between left and right sections broken - left chart component is adopting full screen height, but is now pushed below the header causing the legend to be below the fold, only visible on scroll, and white gap below map.
- Also included fixes for:
  -  National header spacing/padding around forecast figures
  - Removed unintended border on measuringUnit button on map (until we show the Capacity option)

## How Has This Been Tested?

<img width="1904" alt="image" src="https://user-images.githubusercontent.com/41056982/197135768-79c2f8f8-d59a-4420-9ca7-b9afa01c4285.png">

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
