### PR TITLE
Remove national gsp slice pv & delta maps

### DIFF
--- a/apps/nowcasting-app/components/map/deltaMap.tsx
+++ b/apps/nowcasting-app/components/map/deltaMap.tsx
@@ -71,8 +71,7 @@ const DeltaMap: React.FC<DeltaMapProps> = ({
     targetTime?: string,
     gspDeltas?: Map<string, number>
   ) => { forecastGeoJson: FeatureCollection } = (forecastData, targetTime) => {
-    // Exclude first item as it's not representing gsp area
-    const gspForecastData = forecastData?.forecasts?.slice(1);
+    const gspForecastData = forecastData?.forecasts || [];
     const gspShapeJson = gspShapeData as FeatureCollection;
     const forecastGeoJson = {
       ...gspShapeData,

--- a/apps/nowcasting-app/components/map/pvLatest.tsx
+++ b/apps/nowcasting-app/components/map/pvLatest.tsx
@@ -76,8 +76,7 @@ const PvLatestMap: React.FC<PvLatestMapProps> = ({
     forecastData?: FcAllResData,
     targetTime?: string
   ) => { forecastGeoJson: FeatureCollection } = (forecastData, targetTime) => {
-    // Exclude first item as it's not representing gsp area
-    const gspForecastData = forecastData?.forecasts?.slice(1);
+    const gspForecastData = forecastData?.forecasts || [];
     const gspShapeJson = gspShapeData as FeatureCollection;
     const forecastGeoJson = {
       ...gspShapeData,


### PR DESCRIPTION
# Pull Request

## Description

Remove `slice(1)` function as we are now able to get `/forecast/all` data without the first GSP being National (GSP_0).

Fixes #

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
