### PR TITLE
use `inverter_capacity_kw`

### DIFF
--- a/apps/nowcasting-app/components/charts/solar-site-view/solar-site-chart.tsx
+++ b/apps/nowcasting-app/components/charts/solar-site-view/solar-site-chart.tsx
@@ -76,7 +76,7 @@ const SolarSiteChart: FC<{
   const selectedSiteData = combinedSitesData.allSitesData?.filter(
     (site) => site.site_uuid === clickedSiteGroupId
   );
-  const selectedSiteCapacity = selectedSiteData?.[0]?.installed_capacity_kw || 0;
+  const selectedSiteCapacity = selectedSiteData?.[0]?.inverter_capacity_kw || 0;
   const filteredChartData = useFormatChartDataSites({
     allSitesData: selectedSiteData,
     pvForecastData: combinedSitesData.sitesPvForecastData,

--- a/apps/nowcasting-app/components/hooks/useFormatSitesData.tsx
+++ b/apps/nowcasting-app/components/hooks/useFormatSitesData.tsx
@@ -70,7 +70,7 @@ export const useFormatSitesData = (
       const site = combinedSitesData.allSitesData?.[i];
       if (!site) continue;
       const lastSite = (combinedSitesData?.allSitesData || []).length - 1 === Number(i);
-      const siteCapacity = site.installed_capacity_kw;
+      const siteCapacity = site.inverter_capacity_kw;
       const siteActualPV = getPvActualGenerationForSite(
         combinedSitesData.sitesPvActualData,
         site.site_uuid,

--- a/apps/nowcasting-app/components/types.d.ts
+++ b/apps/nowcasting-app/components/types.d.ts
@@ -138,7 +138,8 @@ export type Site = {
   tilt: string;
   latitude: number;
   longitude: number;
-  installed_capacity_kw: number;
+  inverter_capacity_kw: number;
+  module_capacity_kw: number;
 };
 
 export type AllSites = {


### PR DESCRIPTION
# Pull Request

## Description

Fix bug on site level. The site object no longer as `installed_capacity_kw` but has `inverter_capacity_kw` and `module_capacity_kw`

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
