### PR TITLE
update plevel font color in tooltip

### DIFF
--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -62,7 +62,7 @@ const toolTipColors: Record<string, string> = {
   "4HR_FORECAST": orange,
   "4HR_PAST_FORECAST": orange,
   DELTA: deltaPos,
-  PROBABILISTIC_RANGE: "white"
+  PROBABILISTIC_RANGE: yellow
 };
 type RemixLineProps = {
   timeOfInterest: string;
@@ -470,6 +470,7 @@ const RemixLine: React.FC<RemixLineProps> = ({
                     {/* adding probabilistic values to the tooltip */}
                     {Object.entries(toolTiplabels).map(([key, name]) => {
                       const value = data[key];
+                      const color = toolTipColors[key];
                       const pLevelLabels = ["P 10%", "P 90%"];
                       const pLevelComputed = pLevelLabels.map((pLevel: any) => (
                         <li key={key}>{pLevel}:</li>
@@ -486,7 +487,7 @@ const RemixLine: React.FC<RemixLineProps> = ({
                           : null;
                       if (key === "PROBABILISTIC_RANGE" && !deltaView)
                         return (
-                          <li className={`font-sans`}>
+                          <li className={`font-sans`} style={{ color }}>
                             <div className={`flex justify-between`}>
                               {/* <div>PROBABILISTIC_RANGE: </div> */}
                               <div className={`font-sans ml-14`}>{pLevelComputed}</div>


### PR DESCRIPTION
# Pull Request

## Description
Font color for plevels in the tooltip are now yellow. 

<img width="669" alt="Screenshot 2023-07-14 at 09 34 00" src="https://github.com/openclimatefix/nowcasting/assets/86949265/e34e1af9-4136-4781-b540-4036b175b8be">

Fixes #377 

## How Has This Been Tested?

Code was run locally. 

- [x] Yes


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
