### PR TITLE
hide plevel values when one value is NaN

### DIFF
--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -477,6 +477,11 @@ const RemixLine: React.FC<RemixLineProps> = ({
                       ));
                       if (key === "PROBABILISTIC_RANGE" && !value) return null;
                       if (key === "PROBABILISTIC_RANGE" && deltaView) return null;
+                      if (
+                        key === "PROBABILISTIC_RANGE" &&
+                        (value[0] !== "number" || value[1] !== "number")
+                      )
+                        return null;
                       const pLevelValue =
                         key === "PROBABILISTIC_RANGE" && value
                           ? value.map((v: any) => (


### PR DESCRIPTION
# Pull Request

## Description

When plevel value NaN, plevel values are not shown. 

Fixes #379 

## How Has This Been Tested?

Code was run locally. 
- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
