### PR TITLE
return null if plevel values < 0

### DIFF
--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -483,6 +483,8 @@ const RemixLine: React.FC<RemixLineProps> = ({
                         typeof value[1] !== "number"
                       )
                         return null;
+                      if ((key === "PROBABILISTIC_RANGE" && value[0] < 0) || value[1] < 0)
+                        return null;
                       const pLevelValue =
                         key === "PROBABILISTIC_RANGE" && value
                           ? value.map((v: any) => (

--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -483,12 +483,16 @@ const RemixLine: React.FC<RemixLineProps> = ({
                         typeof value[1] !== "number"
                       )
                         return null;
-                      if (key === "PROBABILISTIC_RANGE" && (value[0] < 0 || value[1] < 0)) return 0;
+                      if (
+                        key === "PROBABILISTIC_RANGE" &&
+                        (Math.round(value[0] * 10) < 0 || Math.round(value[1] * 10) < 0)
+                      )
+                        return null;
                       const pLevelValue =
                         key === "PROBABILISTIC_RANGE" && value
                           ? value.map((v: any) => (
                               <li key={key} className={`flex justify-end`}>
-                                {prettyPrintYNumberWithCommas(String(v), 1)}
+                                {prettyPrintYNumberWithCommas(String(v), 1).replace("-", "")}
                               </li>
                             ))
                           : null;

--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -483,8 +483,7 @@ const RemixLine: React.FC<RemixLineProps> = ({
                         typeof value[1] !== "number"
                       )
                         return null;
-                      if ((key === "PROBABILISTIC_RANGE" && value[0] < 0) || value[1] < 0)
-                        return null;
+                      if (key === "PROBABILISTIC_RANGE" && (value[0] < 0 || value[1] < 0)) return 0;
                       const pLevelValue =
                         key === "PROBABILISTIC_RANGE" && value
                           ? value.map((v: any) => (
@@ -497,7 +496,6 @@ const RemixLine: React.FC<RemixLineProps> = ({
                         return (
                           <li className={`font-sans`} style={{ color }}>
                             <div className={`flex justify-between`}>
-                              {/* <div>PROBABILISTIC_RANGE: </div> */}
                               <div className={`font-sans ml-14`}>{pLevelComputed}</div>
                               <div>{pLevelValue}</div>
                             </div>

--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -485,7 +485,7 @@ const RemixLine: React.FC<RemixLineProps> = ({
                         return null;
                       if (
                         key === "PROBABILISTIC_RANGE" &&
-                        (Math.round(value[0] * 10) < 0 || Math.round(value[1] * 10) < 0)
+                        (Math.round(value[0] * 100) < 0 || Math.round(value[1] * 100) < 0)
                       )
                         return null;
                       const pLevelValue =

--- a/apps/nowcasting-app/components/types.d.ts
+++ b/apps/nowcasting-app/components/types.d.ts
@@ -30,11 +30,19 @@ type ForecastValue = {
   targetTime: string;
   expectedPowerGenerationMegawatts: number;
   expectedPowerGenerationNormalized: number | null;
+  plevels: {
+    plevel_10: number;
+    plevel_90: number;
+  };
 };
 type ForecastData = {
   targetTime: string;
   expectedPowerGenerationMegawatts: number;
   expectedPowerGenerationNormalized?: number | null;
+  plevels: {
+    plevel_10: number;
+    plevel_90: number;
+  };
 }[];
 type PvRealData = {
   datetimeUtc: string;


### PR DESCRIPTION


# Pull Request

## Description
Added a condition to the `Tooltip code` to not show plevel values when plevel values are < 0. This might not happen often but occasionally a negative number might make its way through the API for mysterious and unknown reasons. 

Fixes #379 

## How Has This Been Tested?

Code was run and viewed locally. 

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
