### PR TITLE
Add UI tag to routes

### DIFF
--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/use-get-gsp-data.ts
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/use-get-gsp-data.ts
@@ -20,7 +20,7 @@ const useGetGspData = (gspId: number) => {
       datetimeUtc: string;
       solarGenerationKw: number;
     }[]
-  >(`${API_PREFIX}/solar/GB/gsp/pvlive/${gspId}?regime=in-day`, axiosFetcherAuth, {
+  >(`${API_PREFIX}/solar/GB/gsp/pvlive/${gspId}?regime=in-day&UI`, axiosFetcherAuth, {
     refreshInterval: t5min
   });
 
@@ -29,13 +29,13 @@ const useGetGspData = (gspId: number) => {
       datetimeUtc: string;
       solarGenerationKw: number;
     }[]
-  >(`${API_PREFIX}/solar/GB/gsp/pvlive/${gspId}?regime=day-after`, axiosFetcherAuth, {
+  >(`${API_PREFIX}/solar/GB/gsp/pvlive/${gspId}?regime=day-after&UI`, axiosFetcherAuth, {
     refreshInterval: t5min
   });
 
   const { data: gsp4HourData, error: pv4HourError } = useSWR<ForecastValue[]>(
     show4hView
-      ? `${API_PREFIX}/solar/GB/gsp/forecast/${gspId}?forecast_horizon_minutes=240&historic=true&only_forecast_values=true`
+      ? `${API_PREFIX}/solar/GB/gsp/forecast/${gspId}?forecast_horizon_minutes=240&historic=true&only_forecast_values=true&UI`
       : null,
     axiosFetcherAuth,
     {

--- a/apps/nowcasting-app/components/layout/layout.tsx
+++ b/apps/nowcasting-app/components/layout/layout.tsx
@@ -12,7 +12,7 @@ const Layout = ({ children }: ILayout) => {
   const { data: solarStatus } = useSWR<{
     status: string;
     message: string;
-  }>(`${API_PREFIX}/solar/GB/status`, axiosFetcherAuth, {
+  }>(`${API_PREFIX}/solar/GB/status?UI`, axiosFetcherAuth, {
     refreshInterval: 60 * 1000 * 5 // 5min
   });
 

--- a/apps/nowcasting-app/constant.ts
+++ b/apps/nowcasting-app/constant.ts
@@ -6,7 +6,7 @@ export const MAX_POWER_GENERATED = 500;
 export const MAX_NATIONAL_GENERATION_MW = 12000;
 
 export const getAllForecastUrl = (isNormalized: boolean, isHistoric: boolean) =>
-  `${API_PREFIX}/solar/GB/gsp/forecast/all/?${isHistoric ? "historic=true" : ""}${
+  `${API_PREFIX}/solar/GB/gsp/forecast/all/?UI&${isHistoric ? "historic=true" : ""}${
     isNormalized ? "&normalize=true" : ""
   }`;
 

--- a/apps/nowcasting-app/pages/index.tsx
+++ b/apps/nowcasting-app/pages/index.tsx
@@ -155,21 +155,21 @@ export default function Home({ dashboardModeServer }: { dashboardModeServer: str
   // };
 
   const { data: nationalForecastData, error: nationalForecastError } = useSWR<ForecastData>(
-    `${API_PREFIX}/solar/GB/national/forecast?historic=false&only_forecast_values=true`,
+    `${API_PREFIX}/solar/GB/national/forecast?historic=false&only_forecast_values=true&UI`,
     axiosFetcherAuth,
     {
       refreshInterval: 60 * 1000 * 5 // 5min
     }
   );
   const { data: pvRealDayInData, error: pvRealDayInError } = useSWR<PvRealData>(
-    `${API_PREFIX}/solar/GB/national/pvlive?regime=in-day`,
+    `${API_PREFIX}/solar/GB/national/pvlive?regime=in-day&UI`,
     axiosFetcherAuth,
     {
       refreshInterval: 60 * 1000 * 5 // 5min
     }
   );
   const { data: pvRealDayAfterData, error: pvRealDayAfterError } = useSWR<PvRealData>(
-    `${API_PREFIX}/solar/GB/national/pvlive?regime=day-after`,
+    `${API_PREFIX}/solar/GB/national/pvlive?regime=day-after&UI`,
     axiosFetcherAuth,
     {
       refreshInterval: 60 * 1000 * 5 // 5min
@@ -177,7 +177,7 @@ export default function Home({ dashboardModeServer }: { dashboardModeServer: str
   );
   const { data: national4HourData, error: national4HourError } = useSWR<National4HourData>(
     show4hView
-      ? `${API_PREFIX}/solar/GB/national/forecast?forecast_horizon_minutes=240&historic=true&only_forecast_values=true`
+      ? `${API_PREFIX}/solar/GB/national/forecast?forecast_horizon_minutes=240&historic=true&only_forecast_values=true&UI`
       : null,
     axiosFetcherAuth,
     {
@@ -185,14 +185,14 @@ export default function Home({ dashboardModeServer }: { dashboardModeServer: str
     }
   );
   const { data: allGspForecastData, error: allGspForecastError } = useSWR<GspAllForecastData>(
-    `${API_PREFIX}/solar/GB/gsp/forecast/all/?historic=true`,
+    `${API_PREFIX}/solar/GB/gsp/forecast/all/?historic=true&UI`,
     axiosFetcherAuth,
     {
       refreshInterval: 60 * 1000 * 5 // 5min
     }
   );
   const { data: allGspRealData, error: allGspRealError } = useSWR<AllGspRealData>(
-    `${API_PREFIX}/solar/GB/gsp/pvlive/all?regime=in-day`,
+    `${API_PREFIX}/solar/GB/gsp/pvlive/all?regime=in-day&UI`,
     axiosFetcherAuth,
     {
       refreshInterval: 60 * 1000 * 5 // 5min
@@ -285,7 +285,7 @@ export default function Home({ dashboardModeServer }: { dashboardModeServer: str
 
   // Sites API data
   const { data: allSitesData, error: allSitesError } = useSWR<AllSites>(
-    `${SITES_API_PREFIX}/sites`,
+    `${SITES_API_PREFIX}/sites?UI`,
     axiosFetcherAuth,
     {
       isPaused: () => {
@@ -298,7 +298,7 @@ export default function Home({ dashboardModeServer }: { dashboardModeServer: str
   const siteUuids = slicedSitesData.map((site) => site.site_uuid);
   const siteUuidsString = siteUuids?.join(",");
   const { data: sitePvForecastData, error: sitePvForecastError } = useSWR<SitesPvForecast, any>(
-    `${SITES_API_PREFIX}/sites/pv_forecast?site_uuids=${siteUuidsString}`,
+    `${SITES_API_PREFIX}/sites/pv_forecast?site_uuids=${siteUuidsString}&UI`,
     axiosFetcherAuth,
     {
       isPaused: () => !siteUuidsString?.length || !currentView(VIEWS.SOLAR_SITES),
@@ -308,7 +308,7 @@ export default function Home({ dashboardModeServer }: { dashboardModeServer: str
   );
 
   const { data: sitesPvActualData, error: sitePvActualError } = useSWR<SitesPvActual>(
-    `${SITES_API_PREFIX}/sites/pv_actual?site_uuids=${siteUuidsString}`,
+    `${SITES_API_PREFIX}/sites/pv_actual?site_uuids=${siteUuidsString}&UI`,
     axiosFetcherAuth,
     {
       isPaused: () => !siteUuidsString?.length || !currentView(VIEWS.SOLAR_SITES),


### PR DESCRIPTION
👋 hi all, Robert Monarch's Coursera course brought me here. I'm hoping I can make myself useful 🙂

# Pull Request

## Description

Adds a URL param to identify requests coming directly from the web app

Fixes https://github.com/openclimatefix/nowcasting/issues/373 - lmk if I misunderstood the intention here!

## How Has This Been Tested?

I ran the web app and API locally and checked that the param was propagated and persisted to Postgres in some test queries. Example:

```
postgres=# select * from (select distinct on (url, email) * from api_request join "user" on user_uuid = "user".uuid where url like '%national/forecast%' and email not like '%openclimatefix%' order by url, email, created_utc desc) as anon_1 where created_utc > '2023-06-20' order by created_utc desc;

                 uuid                 |                                               url                                               |              user_uuid               |          created_utc          |                 uuid                 |  email
--------------------------------------+-------------------------------------------------------------------------------------------------+--------------------------------------+-------------------------------+--------------------------------------+---------
 b7d9dc1c-32f7-4fb9-be6d-f69b1478c2e1 | http://localhost:8000/v0/solar/GB/national/forecast?historic=false&only_forecast_values=true&UI | 4ad2d486-51b8-44d3-bfea-1adcdc225a4b | 2023-07-22 17:59:22.880993+00 | 4ad2d486-51b8-44d3-bfea-1adcdc225a4b | unknown
 (1 row)
```

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
