### PR TITLE
change api call for gsp chart to call one gsp 

### DIFF
--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/index.tsx
@@ -40,12 +40,19 @@ const GspPvRemixChart: FC<{
   deltaView = false
 }) => {
   //when adding 4hour forecast data back in, add gsp4HourData to list in line 27
-  const { errors, fcAll, pvRealDataAfter, pvRealDataIn, gsp4HourData } = useGetGspData(gspId);
-  const gspData = fcAll?.forecasts.find((fc) => fc.location.gspId === gspId);
-  const gspForecastData = gspData?.forecastValues;
-  const gspInfo = gspData?.location;
+  const {
+    errors,
+    pvRealDataAfter,
+    pvRealDataIn,
+    gspLocationInfo,
+    gspForecastDataOneGSP,
+    gsp4HourData
+  } = useGetGspData(gspId);
+  // const gspData = fcAll?.forecasts.find((fc) => fc.location.gspId === gspId);
+  const gspInstalledCapacity = gspLocationInfo?.[0]?.installedCapacityMw;
+  const gspName = gspLocationInfo?.[0]?.regionName;
   const chartData = useFormatChartData({
-    forecastData: gspForecastData,
+    forecastData: gspForecastDataOneGSP,
     fourHourData: gsp4HourData,
     pvRealDayInData: pvRealDataIn,
     pvRealDayAfterData: pvRealDataAfter,
@@ -56,20 +63,15 @@ const GspPvRemixChart: FC<{
     console.log(errors);
     return <div>failed to load</div>;
   }
-  // if (!fcAll || !pvRealDataIn || !pvRealDataAfter)
-  //   return (
-  //     <div className="mt-8">
-  //       {/* Header spacer */}
-  //       <div className="h-16"></div>
-  //       <div className="h-60 flex flex-1">
-  //         <Spinner />
-  //       </div>
-  //     </div>
-  //   );
+  console.log("gspForecastDataOneGSP", gspForecastDataOneGSP);
+  console.log("chartdata", chartData);
+  console.log("gspName", gspLocationInfo?.installedCapacityMw);
+
   const now30min = formatISODateString(get30MinNow());
-  const dataMissing = !fcAll || !pvRealDataIn || !pvRealDataAfter;
-  const forecastAtSelectedTime: NonNullable<typeof gspForecastData>[number] =
-    gspForecastData?.find((fc) => formatISODateString(fc?.targetTime) === now30min) || ({} as any);
+  const dataMissing = !gspForecastDataOneGSP || !pvRealDataIn || !pvRealDataAfter;
+  const forecastAtSelectedTime: NonNullable<typeof gspForecastDataOneGSP>[number] =
+    gspForecastDataOneGSP?.find((fc) => formatISODateString(fc?.targetTime) === now30min) ||
+    ({} as any);
   const pvPercentage = (forecastAtSelectedTime.expectedPowerGenerationNormalized || 0) * 100;
 
   const fourHourForecastAtSelectedTime: ForecastValue =
@@ -94,14 +96,14 @@ const GspPvRemixChart: FC<{
   );
 
   // Get the next OCF forecast for the last PV value time
-  const correspondingLatestPvForecast = gspForecastData?.find(
+  const correspondingLatestPvForecast = gspForecastDataOneGSP?.find(
     (fc) => formatISODateString(fc.targetTime) === pvForecastDatetime
   );
   const correspondingLatestPvForecastInMW =
     correspondingLatestPvForecast?.expectedPowerGenerationMegawatts || 0;
   // Get the next OCF forecast
   const followingPvForecastInMW =
-    gspForecastData?.find(
+    gspForecastDataOneGSP?.find(
       (fc) => formatISODateString(fc.targetTime) === followingPvForecastDateString
     )?.expectedPowerGenerationMegawatts || 0;
 
@@ -112,7 +114,7 @@ const GspPvRemixChart: FC<{
   //
 
   // set ymax to the installed capacity of the graph
-  let yMax = gspInfo?.installedCapacityMw || 100;
+  let yMax = gspInstalledCapacity || 100;
   yMax = getRoundedTickBoundary(yMax, yMax_levels);
 
   return (
@@ -120,7 +122,7 @@ const GspPvRemixChart: FC<{
       <div className="flex-initial">
         <ForecastHeaderGSP
           onClose={close}
-          title={gspInfo?.regionName || ""}
+          title={gspName || ""}
           mwpercent={Math.round(pvPercentage)}
           pvTimeOnly={convertISODateStringToLondonTime(latestPvActualDatetime)}
           pvValue={Number(latestPvActualInMW)?.toFixed(1)}
@@ -135,9 +137,10 @@ const GspPvRemixChart: FC<{
           <span className="font-semibold dash:3xl:text-5xl dash:xl:text-4xl xl:text-3xl lg:text-2xl md:text-xl text-lg leading-none text-ocf-yellow-500">
             {Math.round(forecastAtSelectedTime.expectedPowerGenerationMegawatts || 0)}
           </span>
+
           <span className="font-semibold dash:3xl:text-5xl dash:xl:text-4xl xl:text-3xl lg:text-2xl md:text-xl text-lg leading-none text-white">
             {" "}
-            / {gspInfo?.installedCapacityMw}
+            / {gspInstalledCapacity}
           </span>
           <span className="text-xs dash:text-2xl text-ocf-gray-300"> MW</span>
         </ForecastHeaderGSP>
@@ -157,7 +160,7 @@ const GspPvRemixChart: FC<{
           resetTime={resetTime}
           visibleLines={visibleLines}
           deltaView={deltaView}
-          deltaYMaxOverride={Math.ceil(Number(gspInfo?.installedCapacityMw) / 200) * 100 || 500}
+          deltaYMaxOverride={Math.ceil(Number(gspInstalledCapacity) / 200) * 100 || 500}
         />
       </div>
     </>

--- a/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/use-get-gsp-data.ts
+++ b/apps/nowcasting-app/components/charts/gsp-pv-remix-chart/use-get-gsp-data.ts
@@ -1,19 +1,19 @@
 import useSWR from "swr";
 import { API_PREFIX, getAllForecastUrl } from "../../../constant";
-import { FcAllResData, ForecastValue } from "../../types";
+import { FcAllResData, ForecastData, ForecastValue, GspEntity } from "../../types";
 import useGlobalState from "../../helpers/globalState";
 import { axiosFetcherAuth } from "../../helpers/utils";
 
 const t5min = 60 * 1000 * 5;
 const useGetGspData = (gspId: number) => {
   const [show4hView] = useGlobalState("show4hView");
-  const { data: fcAll, error: fcAllError } = useSWR<FcAllResData>(
-    getAllForecastUrl(true, true),
-    axiosFetcherAuth,
-    {
-      refreshInterval: t5min
-    }
-  );
+  // const { data: fcAll, error: fcAllError } = useSWR<FcAllResData>(
+  //   getAllForecastUrl(true, true),
+  //   axiosFetcherAuth,
+  //   {
+  //     refreshInterval: t5min
+  //   }
+  // );
 
   const { data: pvRealDataIn, error: pvRealInDat } = useSWR<
     {
@@ -33,6 +33,24 @@ const useGetGspData = (gspId: number) => {
     refreshInterval: t5min
   });
 
+  //add new useSWR for gspChartData
+  const { data: gspForecastDataOneGSP, error: gspForecastDataOneGSPError } = useSWR<ForecastData>(
+    `${API_PREFIX}/solar/GB/gsp/forecast/${gspId}?forecast_horizon_minutes=0&historic=false&only_forecast_values=true`,
+    axiosFetcherAuth,
+    {
+      refreshInterval: 60 * 1000 * 5 // 5min
+    }
+  );
+
+  //add new useSWR for gspLocationInfo
+  const { data: gspLocationInfo, error: gspLocationError } = useSWR<GspEntity>(
+    `${API_PREFIX}/system/GB/gsp/?gsp_id=${gspId}`,
+    axiosFetcherAuth,
+    {
+      refreshInterval: 60 * 1000 * 5 // 5min
+    }
+  );
+
   const { data: gsp4HourData, error: pv4HourError } = useSWR<ForecastValue[]>(
     show4hView
       ? `${API_PREFIX}/solar/GB/gsp/forecast/${gspId}?forecast_horizon_minutes=240&historic=true&only_forecast_values=true`
@@ -44,11 +62,18 @@ const useGetGspData = (gspId: number) => {
   );
 
   return {
-    errors: [fcAllError, pvRealInDat, pvRealDayAfter, pv4HourError].filter((e) => !!e),
-    fcAll,
+    errors: [
+      pvRealInDat,
+      pvRealDayAfter,
+      gspForecastDataOneGSPError,
+      gspLocationError,
+      pv4HourError
+    ].filter((e) => !!e),
     gsp4HourData,
     pvRealDataIn,
-    pvRealDataAfter
+    pvRealDataAfter,
+    gspForecastDataOneGSP,
+    gspLocationInfo
   };
 };
 

--- a/apps/nowcasting-app/pages/index.tsx
+++ b/apps/nowcasting-app/pages/index.tsx
@@ -252,16 +252,16 @@ export default function Home({ dashboardModeServer }: { dashboardModeServer: str
         deltaBucketKey: DELTA_BUCKET[deltaBucket]
       });
     }
-    console.log("gspDeltas calculated");
-    console.log(
-      "gspDeltas",
-      Array.from(tempGspDeltas)
-        .filter((gspDelta) => gspDelta[1].delta > 0)
-        .map((gspDelta, index) => {
-          const delta = gspDelta[1].delta;
-          return delta;
-        })
-    );
+    // console.log("gspDeltas calculated");
+    // console.log(
+    //   "gspDeltas",
+    //   Array.from(tempGspDeltas)
+    //     .filter((gspDelta) => gspDelta[1].delta > 0)
+    //     .map((gspDelta, index) => {
+    //       const delta = gspDelta[1].delta;
+    //       return delta;
+    //     })
+    // );
     return tempGspDeltas;
   }, [allGspForecastData, allGspRealData, selectedTime]);
 


### PR DESCRIPTION
# Pull Request

## Description
Update to the GSP remix chart code to query one gsp for the chart display data

Fixes # 392

## How Has This Been Tested?

The code has been run locally using v1.4.8 of the API. 

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked my code and corrected any misspellings
