### PR TITLE
Issue/365 loading states

### DIFF
--- a/apps/nowcasting-app/components/charts/DataLoadingChartStatus.tsx
+++ b/apps/nowcasting-app/components/charts/DataLoadingChartStatus.tsx
@@ -1,0 +1,18 @@
+import { LoadingState } from "../types";
+import { SpinnerTextInline } from "../icons/icons";
+import { FC } from "react";
+
+const DataLoadingChartStatus: FC<{ loadingState: LoadingState }> = ({ loadingState }) => {
+  if (!loadingState.showMessage || !loadingState.message.length) return null;
+
+  return (
+    <div className="absolute -top-4 right-4 flex items-center h-9">
+      <div className="flex flex-row h-6 justify-between items-center bg-mapbox-black rounded-sm px-2 pl-1.5">
+        <SpinnerTextInline className="mr-2"></SpinnerTextInline>
+        <div className="text-sm text-ocf-gray-500">{loadingState.message}</div>
+      </div>
+    </div>
+  );
+};
+
+export default DataLoadingChartStatus;

--- a/apps/nowcasting-app/components/charts/delta-view/delta-view-chart.tsx
+++ b/apps/nowcasting-app/components/charts/delta-view/delta-view-chart.tsx
@@ -20,6 +20,7 @@ import DeltaForecastLabel from "../../delta-forecast-label";
 import DeltaBuckets from "./delta-buckets-ui";
 import useTimeNow from "../../hooks/use-time-now";
 import { ChartLegend } from "../ChartLegend";
+import DataLoadingChartStatus from "../DataLoadingChartStatus";
 
 const LegendItem: FC<{
   iconClasses: string;
@@ -277,6 +278,7 @@ const DeltaChart: FC<DeltaChartProps> = ({ className, combinedData, combinedErro
   const [selectedISOTime, setSelectedISOTime] = useGlobalState("selectedISOTime");
   const [timeNow] = useGlobalState("timeNow");
   const [forecastCreationTime] = useGlobalState("forecastCreationTime");
+  const [loadingState] = useGlobalState("loadingState");
   const { stopTime, resetTime } = useStopAndResetTime();
   const selectedTime = formatISODateString(selectedISOTime || new Date().toISOString());
   const selectedTimeHalfHourSlot = getNext30MinSlot(new Date(selectedTime));
@@ -363,6 +365,7 @@ const DeltaChart: FC<DeltaChartProps> = ({ className, combinedData, combinedErro
         ></ForecastHeader>
 
         <div className="flex-1 relative min-h-[30vh] max-h-[40vh] h-auto mt-4">
+          <DataLoadingChartStatus loadingState={loadingState} />
           <RemixLine
             resetTime={resetTime}
             timeNow={formatISODateString(timeNow)}

--- a/apps/nowcasting-app/components/charts/pv-remix-chart.tsx
+++ b/apps/nowcasting-app/components/charts/pv-remix-chart.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from "react";
+import { FC, useEffect, useMemo, useState } from "react";
 import RemixLine from "./remix-line";
 import ForecastHeader from "./forecast-header";
 import useGlobalState from "../helpers/globalState";
@@ -11,6 +11,7 @@ import { MAX_NATIONAL_GENERATION_MW } from "../../constant";
 import useHotKeyControlChart from "../hooks/use-hot-key-control-chart";
 import { CombinedData, CombinedErrors } from "../types";
 import { ChartLegend } from "./ChartLegend";
+import DataLoadingChartStatus from "./DataLoadingChartStatus";
 
 const PvRemixChart: FC<{
   combinedData: CombinedData;
@@ -25,6 +26,7 @@ const PvRemixChart: FC<{
   const [forecastCreationTime] = useGlobalState("forecastCreationTime");
   const { stopTime, resetTime } = useStopAndResetTime();
   const selectedTime = formatISODateString(selectedISOTime || new Date().toISOString());
+  const [loadingState] = useGlobalState("loadingState");
 
   const {
     nationalForecastData,
@@ -94,6 +96,7 @@ const PvRemixChart: FC<{
               <Spinner></Spinner>
             </div>
           )}
+          <DataLoadingChartStatus loadingState={loadingState} />
           <RemixLine
             resetTime={resetTime}
             timeNow={formatISODateString(timeNow)}

--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -180,9 +180,9 @@ const RemixLine: React.FC<RemixLineProps> = ({
           data={preppedData}
           margin={{
             top: 20,
-            right: 20,
+            right: 16,
             bottom: 20,
-            left: 20
+            left: 16
           }}
           onClick={(e?: { activeLabel?: string }) => {
             if (setTimeOfInterest && e?.activeLabel) {
@@ -413,7 +413,6 @@ const RemixLine: React.FC<RemixLineProps> = ({
 
           <Tooltip
             content={({ payload, label }) => {
-              console.log("payload", payload);
               const data = payload && payload[0]?.payload;
               if (!data || (data["GENERATION"] === 0 && data["FORECAST"] === 0)) return <div></div>;
 
@@ -473,7 +472,7 @@ const RemixLine: React.FC<RemixLineProps> = ({
                       const color = toolTipColors[key];
                       const pLevelLabels = ["P 10%", "P 90%"];
                       const pLevelComputed = pLevelLabels.map((pLevel: any) => (
-                        <li key={key}>{pLevel}:</li>
+                        <li key={key + pLevel}>{pLevel}:</li>
                       ));
                       if (key === "PROBABILISTIC_RANGE" && !value) return null;
                       if (key === "PROBABILISTIC_RANGE" && deltaView) return null;
@@ -490,8 +489,8 @@ const RemixLine: React.FC<RemixLineProps> = ({
                         return null;
                       const pLevelValue =
                         key === "PROBABILISTIC_RANGE" && value
-                          ? value.map((v: any) => (
-                              <li key={key} className={`flex justify-end`}>
+                          ? value.map((v: any, index: number) => (
+                              <li key={key + String(index)} className={`flex justify-end`}>
                                 {prettyPrintYNumberWithCommas(String(v), 1).replace("-", "")}
                               </li>
                             ))

--- a/apps/nowcasting-app/components/helpers/globalState.tsx
+++ b/apps/nowcasting-app/components/helpers/globalState.tsx
@@ -7,6 +7,7 @@ import {
   getBooleanSettingFromLocalStorage,
   CookieStorageKeys
 } from "./cookieStorage";
+import { LoadingState } from "../types";
 
 export function get30MinNow(offsetMinutes = 0) {
   // this is a function to get the date of now, but rounded up to the closest 30 minutes
@@ -54,6 +55,7 @@ export type GlobalStateType = {
   dashboardMode: boolean;
   sortBy: SORT_BY;
   autoZoom: boolean;
+  loadingState: LoadingState;
 };
 
 export const { useGlobalState, getGlobalState, setGlobalState } =
@@ -81,7 +83,12 @@ export const { useGlobalState, getGlobalState, setGlobalState } =
     aggregationLevel: AGGREGATION_LEVELS.SITE,
     sortBy: SORT_BY.CAPACITY,
     show4hView: enable4hView && getBooleanSettingFromLocalStorage(CookieStorageKeys.FOUR_HOUR_VIEW),
-    dashboardMode: getBooleanSettingFromLocalStorage(CookieStorageKeys.DASHBOARD_MODE)
+    dashboardMode: getBooleanSettingFromLocalStorage(CookieStorageKeys.DASHBOARD_MODE),
+    loadingState: {
+      initialLoadComplete: false,
+      showMessage: false,
+      message: "Loading data"
+    }
   });
 
 export default useGlobalState;

--- a/apps/nowcasting-app/components/helpers/utils.ts
+++ b/apps/nowcasting-app/components/helpers/utils.ts
@@ -1,7 +1,6 @@
 import axios from "axios";
-import { API_PREFIX, DELTA_BUCKET, getDeltaBucketKeys } from "../../constant";
-import { NextApiRequest, NextApiResponse } from "next";
-import { Bucket, GspDeltaValue } from "../types";
+import { DELTA_BUCKET, getDeltaBucketKeys } from "../../constant";
+import { Bucket, CombinedLoading, CombinedValidating, GspDeltaValue, LoadingState } from "../types";
 import Router from "next/router";
 import * as Sentry from "@sentry/nextjs";
 
@@ -26,6 +25,46 @@ export const getForecastAccessorForTimeHorizon = (selectedTimeHorizon: number) =
 
 export const classNames = (...classes: string[]) => {
   return classes.filter(Boolean).join(" ");
+};
+
+export const getLoadingState = (
+  combinedLoading: CombinedLoading,
+  combinedValidating: CombinedValidating
+): LoadingState => {
+  let initialLoadComplete = Object.values(combinedLoading).every((loading) => !loading);
+  let showMessage = false;
+  let message = "";
+  if (initialLoadComplete) {
+    if (combinedValidating.nationalForecastValidating) {
+      message = "Loading latest National Forecast";
+      showMessage = true;
+    }
+    if (combinedValidating.pvRealDayInValidating) {
+      message = showMessage ? "Loading latest data" : "Loading latest PV Live Initial";
+      showMessage = true;
+    }
+    if (combinedValidating.pvRealDayAfterValidating) {
+      message = showMessage ? "Loading latest data" : "Loading latest PV Live Updated";
+      showMessage = true;
+    }
+    if (combinedValidating.national4HourValidating) {
+      message = showMessage ? "Loading latest data" : "Loading latest National 4 Hour";
+      showMessage = true;
+    }
+    if (combinedValidating.allGspForecastValidating) {
+      message = showMessage ? "Loading latest data" : "Loading latest GSP Forecast";
+      showMessage = true;
+    }
+    if (combinedValidating.allGspRealValidating) {
+      message = showMessage ? "Loading latest data" : "Loading latest GSP Actual";
+      showMessage = true;
+    }
+  }
+  return {
+    initialLoadComplete,
+    showMessage,
+    message
+  };
 };
 
 /**

--- a/apps/nowcasting-app/components/hooks/useLoadDataFromApi.tsx
+++ b/apps/nowcasting-app/components/hooks/useLoadDataFromApi.tsx
@@ -34,6 +34,7 @@ export const useLoadDataFromApi = <T extends APIResponseType>(
   return useSWR<T, Error>(url, axiosFetcherAuth, {
     refreshInterval: t5min,
     dedupingInterval: t2min,
+    keepPreviousData: true,
     onErrorRetry: (error, key, config, revalidate, { retryCount }) => {
       if (error.toString().includes("403")) return;
       if (retryCount >= 10) return;

--- a/apps/nowcasting-app/components/icons/icons.tsx
+++ b/apps/nowcasting-app/components/icons/icons.tsx
@@ -197,3 +197,59 @@ export const Checkmark: React.FC<IconProps> = ({ className }) => (
     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
   </svg>
 );
+
+export const SpinnerSmall = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    className={`animate-spin dark:text-gray-600 fill-white ${props.className}`}
+    width={24}
+    height={24}
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle
+      cx={12}
+      cy={12}
+      r={10.5}
+      stroke="currentColor"
+      fill="none"
+      strokeOpacity={0.25}
+      strokeWidth={3}
+    />
+    <path
+      d="M12 1.5a10.5 10.5 0 019.988 7.26"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={3}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export const SpinnerTextInline = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    className={`animate-spin dark:text-gray-600 fill-white ${props.className}`}
+    width={14}
+    height={14}
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle
+      cx={7}
+      cy={7}
+      r={6}
+      stroke="currentColor"
+      fill="none"
+      strokeOpacity={0.25}
+      strokeWidth={2}
+    />
+    <path
+      d="M7 1a6 6 0 015.707 4.149"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);

--- a/apps/nowcasting-app/components/icons/spinner.tsx
+++ b/apps/nowcasting-app/components/icons/spinner.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 
-type SpinnerProps = {};
+type SpinnerProps = {
+  className?: string;
+};
 
-const Spinner: React.FC<SpinnerProps> = ({}) => {
+const Spinner: React.FC<SpinnerProps> = ({ className = "" }) => {
   return (
     <svg
       role="status"
-      className="w-8 h-8 mr-2 text-ocf-gray-700 m-auto self-center animate-spin dark:text-gray-600 fill-white"
+      className={`w-8 h-8 mr-2 text-ocf-gray-700 m-auto self-center animate-spin dark:text-gray-600 fill-white ${className}`}
       viewBox="0 0 100 101"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/apps/nowcasting-app/components/types.d.ts
+++ b/apps/nowcasting-app/components/types.d.ts
@@ -1,5 +1,10 @@
 import { DELTA_BUCKET } from "../constant";
 
+export type LoadingState = {
+  initialLoadComplete: boolean;
+  showMessage: boolean;
+  message: string;
+};
 export type FcAllResData = {
   type: "FeatureCollection";
   forecasts: {
@@ -52,6 +57,22 @@ type CombinedData = {
   allGspForecastData: GspAllForecastData | undefined;
   allGspRealData: AllGspRealData | undefined;
   gspDeltas: GspDeltas | undefined;
+};
+type CombinedLoading = {
+  nationalForecastLoading: boolean;
+  pvRealDayInLoading: boolean;
+  pvRealDayAfterLoading: boolean;
+  national4HourLoading: boolean;
+  allGspForecastLoading: boolean;
+  allGspRealLoading: boolean;
+};
+type CombinedValidating = {
+  nationalForecastValidating: boolean;
+  pvRealDayInValidating: boolean;
+  pvRealDayAfterValidating: boolean;
+  national4HourValidating: boolean;
+  allGspForecastValidating: boolean;
+  allGspRealValidating: boolean;
 };
 type CombinedErrors = {
   nationalForecastError: any;

--- a/apps/nowcasting-app/package.json
+++ b/apps/nowcasting-app/package.json
@@ -61,7 +61,7 @@
     "lint-staged": "^13.0.3",
     "postcss": "^8.4.13",
     "prettier": "^2.6.2",
-    "swr": "^1.3.0",
+    "swr": "^2.2.0",
     "tailwindcss": "^3.3.2",
     "typescript": "^4.6.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12649,10 +12649,12 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-swr@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/swr/-/swr-1.3.0.tgz#c6531866a35b4db37b38b72c45a63171faf9f4e8"
-  integrity sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==
+swr@2.2:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-2.2.0.tgz#575c6ac1bec087847f4c86a39ccbc0043c834d6a"
+  integrity sha512-AjqHOv2lAhkuUdIiBu9xbuettzAzWXmCEcLONNKJRba87WAefz8Ca9d6ds/SzrPc235n1IxWYdhJ2zF3MNUaoQ==
+  dependencies:
+    use-sync-external-store "^1.2.0"
 
 symbol.prototype.description@^1.0.0:
   version "1.0.5"
@@ -13411,6 +13413,11 @@ use-subscription@1.5.1:
   integrity sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==
   dependencies:
     object-assign "^4.1.1"
+
+use-sync-external-store@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
# Pull Request

## Description

Add some loading states, similar to those suggested in the below issue. Not from designs, so testing and feedback welcome!

- On initial load, and therefore when no data has been loaded yet, the skeleton graph displays the main spinner.
- Data in the app is now "de-duped", so the same API route will not be requested with the same parameters if the latest response is **less than 2 minutes old**.
- On 'refresh' of the data, which happens either from the 5 minute background timer having elapsed, or from a user interaction e.g. with the charts _after_ the 2 minute 'de-dupe' timeout having elapsed, the API requests are re-fetched and the loading message appears.
  - If more than one request is currently pending, "Loading latest data" is displayed;
  - If only one request is pending, the message specifies this, e.g. "Loading latest GSP forecast" – this one shows more often, because at the moment it is large/slow, and called perhaps more often than needed, as @rachel-labri-tipton, @devsjc and I have been discussing recently. I notice from the screenshot below that the message is also perhaps a bit long, so might want shortening.

Fixes #365 

## How Has This Been Tested?

Locally, forcing API to update every 30 seconds and also manually triggering updates to different API endpoints to check messages.

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings

## Screenshots of example loading messages:

<img width="1624" alt="image" src="https://github.com/openclimatefix/nowcasting/assets/41056982/51e50dbe-4a88-4df7-a2ff-bdaf506ab380">

<img width="1624" alt="image" src="https://github.com/openclimatefix/nowcasting/assets/41056982/0a2b2c62-ce9d-4c83-b00d-f1f380a8e49d">

