### PR TITLE
Reformat probabilistic numbers in tooltip

### DIFF
--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -426,6 +426,7 @@ const RemixLine: React.FC<RemixLineProps> = ({
                   <ul className="">
                     {Object.entries(toolTiplabels).map(([key, name]) => {
                       const value = data[key];
+                      console.log("key", key, "value", value, "data", data[key]);
                       if (key === "DELTA" && !deltaView) return null;
                       if (typeof value !== "number") return null;
                       if (deltaView && key === "GENERATION" && data["GENERATION_UPDATED"] >= 0)
@@ -438,6 +439,12 @@ const RemixLine: React.FC<RemixLineProps> = ({
                         : ["PROBABILISTIC_UPPER_BOUND", "PROBABILISTIC_LOWER_BOUND"].includes(key)
                         ? "text-xs"
                         : "font-normal";
+                      const pvLiveTextClass =
+                        data["GENERATION_UPDATED"] >= 0 &&
+                        data["GENERATION"] >= 0 &&
+                        key === "GENERATION"
+                          ? "text-xs"
+                          : "";
                       const sign = ["DELTA"].includes(key) ? (Number(value) > 0 ? "+" : "") : "";
                       const color = ["DELTA"].includes(key)
                         ? Number(value) > 0
@@ -457,7 +464,7 @@ const RemixLine: React.FC<RemixLineProps> = ({
 
                       return (
                         <li className={`font-sans`} key={`item-${key}`} style={{ color }}>
-                          <div className={`flex justify-between ${textClass}`}>
+                          <div className={`flex justify-between ${textClass} ${pvLiveTextClass}`}>
                             <div>{toolTiplabels[key]}: </div>
                             <div className={`font-sans ml-7`}>
                               {(show4hView || key !== "DELTA") && sign}

--- a/apps/nowcasting-app/components/charts/remix-line.tsx
+++ b/apps/nowcasting-app/components/charts/remix-line.tsx
@@ -426,7 +426,6 @@ const RemixLine: React.FC<RemixLineProps> = ({
                   <ul className="">
                     {Object.entries(toolTiplabels).map(([key, name]) => {
                       const value = data[key];
-                      console.log("key", key, "value", value, "data", data[key]);
                       if (key === "DELTA" && !deltaView) return null;
                       if (typeof value !== "number") return null;
                       if (deltaView && key === "GENERATION" && data["GENERATION_UPDATED"] >= 0)
@@ -434,11 +433,10 @@ const RemixLine: React.FC<RemixLineProps> = ({
                       if (key.includes("4HR") && (!show4hView || !visibleLines.includes(key)))
                         return null;
                       if (key.includes("PROBABILISTIC") && Math.round(value * 100) < 0) return null;
-                      const textClass = ["FORECAST", "PAST_FORECAST"].includes(key)
-                        ? "font-semibold"
-                        : ["PROBABILISTIC_UPPER_BOUND", "PROBABILISTIC_LOWER_BOUND"].includes(key)
-                        ? "text-xs"
-                        : "font-normal";
+                      let textClass = "font-normal";
+                      if (["FORECAST", "PAST_FORECAST"].includes(key)) textClass = "font-semibold";
+                      if (["PROBABILISTIC_UPPER_BOUND", "PROBABILISTIC_LOWER_BOUND"].includes(key))
+                        textClass = "text-xs";
                       const pvLiveTextClass =
                         data["GENERATION_UPDATED"] >= 0 &&
                         data["GENERATION"] >= 0 &&
@@ -455,11 +453,7 @@ const RemixLine: React.FC<RemixLineProps> = ({
                         key === "DELTA" &&
                         !show4hView &&
                         `${data["formattedDate"]}:00.000Z` >= currentTime
-                          ? // `${data["formattedDate"]}:00.000Z` >= currentTime ||
-                            // (show4hView &&
-                            //   key.includes("4HR") &&
-                            //   `${data["formattedDate"]}:00.000Z` >= fourHoursFromNow.toISOString())
-                            "-"
+                          ? "-"
                           : prettyPrintYNumberWithCommas(String(value), 1);
 
                       return (

--- a/apps/nowcasting-app/components/charts/use-format-chart-data.tsx
+++ b/apps/nowcasting-app/components/charts/use-format-chart-data.tsx
@@ -115,9 +115,29 @@ const useFormatChartData = ({
           addDataToMap(
             fc,
             (db) => db.targetTime,
-            //add an array here for the probabilistic range. it'll be two numbers [lower, upper]
+            //add an array here for the probabilistic area in the chart
             (db) => ({
               PROBABILISTIC_RANGE: [db.plevels.plevel_10, db.plevels.plevel_90]
+            })
+          );
+        }
+        if (fc.plevels?.plevel_10) {
+          addDataToMap(
+            fc,
+            (db) => db.targetTime,
+            // probabilistic lower bound for the tooltip to use
+            (db) => ({
+              PROBABILISTIC_LOWER_BOUND: db.plevels.plevel_10
+            })
+          );
+        }
+        if (fc.plevels?.plevel_90) {
+          addDataToMap(
+            fc,
+            (db) => db.targetTime,
+            (db) => ({
+              // probabilistic upper bound for the tooltip to use
+              PROBABILISTIC_UPPER_BOUND: db.plevels.plevel_90
             })
           );
         }


### PR DESCRIPTION
# Pull Request

## Description
Updates the formatting for probabilistic numbers in the tooltip. This was discussed here: #384 . 

![Screenshot 2023-11-15 at 11 31 36](https://github.com/openclimatefix/nowcasting/assets/86949265/6b8841d7-298c-4891-973b-928191657b14)

The updated tooltip looks like this. 
It might be noticeable that the `OCF Forecast` is now in semi-bold because the `textClass` applied wasn't working, so I fixed that as well when I set the `textClass` for the P levels and values. 

![Screenshot 2023-11-15 at 12 01 40](https://github.com/openclimatefix/nowcasting/assets/86949265/48b076e6-28e6-4ef3-9d12-3b1097b59bf4)

I updated `useFormatChartData` so that it returns 3 probabilistic things: `PROBABILISTIC_RANGE` as an array for the area plotted on the chart and then `PROBABILISTIC_UPPER_BOUND`and `PROBABILISTIC_LOWER_BOUND` as numbers. This seems repetitive, but when it came to the tooltip, it was easy to just have number values for all tooltip labels.

In terms of review, would like to know if all tooltip numbers are still showing correctly. 

Fixes #384

## How Has This Been Tested?
I ran the code locally. 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
