### PR TITLE
change circle so that area is proportional to expected PV

### DIFF
--- a/apps/nowcasting-app/components/map/sitesMap.tsx
+++ b/apps/nowcasting-app/components/map/sitesMap.tsx
@@ -194,8 +194,9 @@ const SitesMap: React.FC<SitesMapProps> = ({
           expectedPV: site.expectedPV,
           // Make the radius of the circle where the area is proportional to the expectedPV
           // We know expectedPVRadius has to be proportional to sqrt(expectedPV),
+          // But this didn't look good, so took took halfway between linear and area
           // and if expectedPV == capacity, then expectedPVRadius == capacity, therefore
-          expectedPVRadius: Math.sqrt(site.expectedPV * site.capacity),
+          expectedPVRadius: Math.pow(site.expectedPV, 0.67) * Math.pow(site.capacity, 0.34),
           selected: site.id === clickedSiteGroupId
         }
       };

--- a/apps/nowcasting-app/components/map/sitesMap.tsx
+++ b/apps/nowcasting-app/components/map/sitesMap.tsx
@@ -192,6 +192,10 @@ const SitesMap: React.FC<SitesMapProps> = ({
           label: site.label,
           capacity: site.capacity,
           expectedPV: site.expectedPV,
+          // Make the radius of the circle where the area is proportional to the expectedPV
+          // We know expectedPVRadius has to be proportional to sqrt(expectedPV),
+          // and if expectedPV == capacity, then expectedPVRadius == capacity, therefore
+          expectedPVRadius: (site.expectedPV * site.capacity) ^ 0.5,
           selected: site.id === clickedSiteGroupId
         }
       };
@@ -406,7 +410,7 @@ const SitesMap: React.FC<SitesMapProps> = ({
     if (generationLayer) {
       map.setPaintProperty(`Generation-${groupName}`, "circle-radius", [
         "*",
-        ["to-number", ["get", "expectedPV"]],
+        ["to-number", ["get", "expectedPVRadius"]],
         getRingMultiplier(groupAggregationLevel)
       ]);
       // const visibility = currentAggregationLevel === groupAggregationLevel ? "visible" : "none";
@@ -426,7 +430,7 @@ const SitesMap: React.FC<SitesMapProps> = ({
         paint: {
           "circle-radius": [
             "*",
-            ["to-number", ["get", "expectedPV"]],
+            ["to-number", ["get", "expectedPVRadius"]],
             getRingMultiplier(groupAggregationLevel)
           ],
           "circle-color": [

--- a/apps/nowcasting-app/components/map/sitesMap.tsx
+++ b/apps/nowcasting-app/components/map/sitesMap.tsx
@@ -195,7 +195,7 @@ const SitesMap: React.FC<SitesMapProps> = ({
           // Make the radius of the circle where the area is proportional to the expectedPV
           // We know expectedPVRadius has to be proportional to sqrt(expectedPV),
           // and if expectedPV == capacity, then expectedPVRadius == capacity, therefore
-          expectedPVRadius: (site.expectedPV * site.capacity) ^ 0.5,
+          expectedPVRadius: Math.sqrt(site.expectedPV * site.capacity),
           selected: site.id === clickedSiteGroupId
         }
       };


### PR DESCRIPTION
# Pull Request

## Description

Change the radius of the yellow blob to be

`r = expectedpv ^ 0.66`.

Note orginally it was `r = expectedpv^1`, and I tried `r = expectedpv ^ 0.5`, but something looked a bit wrong. The GSPs that were only at 25% went to half the circle and it looked quite filled out. 

Fixes #437

before

<img width="1118" alt="Screenshot 2024-01-24 at 21 37 05" src="https://github.com/openclimatefix/nowcasting/assets/34686298/58896c3e-cabc-4193-a6d0-3be431572be1">

now


<img width="1124" alt="Screenshot 2024-01-24 at 22 12 36" src="https://github.com/openclimatefix/nowcasting/assets/34686298/fca63e2e-6992-4fac-9649-b5ecb7cfe45f">


## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
